### PR TITLE
api: toxiproxy resets

### DIFF
--- a/api.go
+++ b/api.go
@@ -26,8 +26,6 @@ func (server *server) Listen() {
 	r.HandleFunc("/proxies", server.ProxyIndex).Methods("GET")
 	r.HandleFunc("/proxies", server.ProxyCreate).Methods("POST")
 	r.HandleFunc("/proxies/{name}", server.ProxyDelete).Methods("DELETE")
-
-	r.HandleFunc("/reset", server.Reset).Methods("POST")
 	http.Handle("/", r)
 
 	logrus.WithFields(logrus.Fields{
@@ -99,20 +97,6 @@ func (server *server) ProxyDelete(response http.ResponseWriter, request *http.Re
 	_, err = response.Write(nil)
 	if err != nil {
 		logrus.Warn("ProxyIndex: Failed to write headers to client", err)
-	}
-}
-
-func (server *server) Reset(response http.ResponseWriter, request *http.Request) {
-	err := server.collection.Clear()
-	if err != nil {
-		http.Error(response, server.apiError(err, http.StatusNotFound), http.StatusNotFound)
-		return
-	}
-
-	response.WriteHeader(http.StatusNoContent)
-	_, err = response.Write(nil)
-	if err != nil {
-		logrus.Warn("Reset: Failed to write headers to client", err)
 	}
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -29,13 +30,12 @@ func WithServer(t *testing.T, f func(string)) {
 	}
 }
 
-func CreateProxy(t *testing.T, addr string) *http.Response {
-	body := `
+func CreateProxy(t *testing.T, addr string, name string) *http.Response {
+	body := fmt.Sprintf(`
 	{
-		"Name": "mysql_master",
-		"Listen": "localhost:3310",
+		"Name": "%s",
 		"Upstream": "localhost:20001"
-	}`
+	}`, name)
 
 	resp, err := http.Post(addr+"/proxies", "application/json", strings.NewReader(body))
 	if err != nil {
@@ -85,7 +85,7 @@ func TestIndexWithNoProxies(t *testing.T) {
 
 func TestCreateProxy(t *testing.T) {
 	WithServer(t, func(addr string) {
-		if resp := CreateProxy(t, addr); resp.StatusCode != http.StatusCreated {
+		if resp := CreateProxy(t, addr, "mysql_master"); resp.StatusCode != http.StatusCreated {
 			t.Fatal("Unable to create proxy")
 		}
 	})
@@ -93,7 +93,7 @@ func TestCreateProxy(t *testing.T) {
 
 func TestIndexWithProxies(t *testing.T) {
 	WithServer(t, func(addr string) {
-		if resp := CreateProxy(t, addr); resp.StatusCode != http.StatusCreated {
+		if resp := CreateProxy(t, addr, "mysql_master"); resp.StatusCode != http.StatusCreated {
 			t.Fatal("Unable to create proxy")
 		}
 
@@ -106,7 +106,7 @@ func TestIndexWithProxies(t *testing.T) {
 
 func TestDeleteProxy(t *testing.T) {
 	WithServer(t, func(addr string) {
-		if resp := CreateProxy(t, addr); resp.StatusCode != http.StatusCreated {
+		if resp := CreateProxy(t, addr, "mysql_master"); resp.StatusCode != http.StatusCreated {
 			t.Fatal("Unable to create proxy")
 		}
 
@@ -128,11 +128,11 @@ func TestDeleteProxy(t *testing.T) {
 
 func TestCreateProxyTwice(t *testing.T) {
 	WithServer(t, func(addr string) {
-		if resp := CreateProxy(t, addr); resp.StatusCode != http.StatusCreated {
+		if resp := CreateProxy(t, addr, "mysql_master"); resp.StatusCode != http.StatusCreated {
 			t.Fatal("Unable to create proxy")
 		}
 
-		if resp := CreateProxy(t, addr); resp.StatusCode != http.StatusConflict {
+		if resp := CreateProxy(t, addr, "mysql_master"); resp.StatusCode != http.StatusConflict {
 			t.Fatal("Expected http.StatusConflict Conflict back from API")
 		}
 	})
@@ -146,19 +146,26 @@ func TestDeleteNonExistantProxy(t *testing.T) {
 	})
 }
 
-func TestCreateProxyAndReset(t *testing.T) {
+func TestCreateProxyAndRemoveByWildcard(t *testing.T) {
 	WithServer(t, func(addr string) {
-		if resp := CreateProxy(t, addr); resp.StatusCode != http.StatusCreated {
-			t.Fatal("Unable to create proxy")
+		if resp := CreateProxy(t, addr, "mysql_master"); resp.StatusCode != http.StatusCreated {
+			t.Fatal("Expected http.StatusConflict Conflict back from API")
 		}
 
-		_, err := http.Post(addr+"/reset", "application/json", strings.NewReader(""))
-		if err != nil {
-			t.Fatal("Unable to delete proxy")
+		if resp := CreateProxy(t, addr, "mysql_slave"); resp.StatusCode != http.StatusCreated {
+			t.Fatal("Expected http.StatusConflict Conflict back from API")
 		}
 
-		if len(ListProxies(t, addr)) > 0 {
-			t.Error("Expected no proxies in list")
+		if len(ListProxies(t, addr)) != 2 {
+			t.Fatal("Expected to have created two new proxies")
+		}
+
+		if resp := DeleteProxy(t, addr, "mysql_.*"); resp.StatusCode != http.StatusNoContent {
+			t.Fatal("Expected to delete all mysql proxies with wildcard")
+		}
+
+		if len(ListProxies(t, addr)) != 0 {
+			t.Fatal("Expected all proxies to be deleted")
 		}
 	})
 }


### PR DESCRIPTION
Earlier today I merged https://github.com/Shopify/toxiproxy/pull/3 to be able to create a JSON configuration file to specify which proxies `toxiproxy` should set up at boot. The goal here is that `toxiproxy` is consistent between CI and Development, without having to update in multiple repos every time you want to make a change.

The configuration file has a number of problems. It means starting `toxiproxy` in Vagrant becomes more problematic. What happens if the Shopify repo is not there? What happens if you add another Shopify project that should use `toxiproxy`? Do you have to keep this state both in the cookbooks and in Shopify then? What happens when you change branches and the configuration changes?

A simpler approach is to spawn a `toxiproxy` that lives for the duration of the Rails process, or even test, as have been discussed earlier, but that's super prone to break and leave around orphaned processes. You can also do something crazy with a filewatch, but that requires more configuration for multiple projects and is fragile.

Instead, the approach is:
1. In `config/boot.rb`, before any network connections in Shopify is established, we `DELETE` all relevant proxies in `toxiproxy` (namespaced with e.g. `shopify_*`, to allow for multiple applications to use the same `toxiproxy` for testing, but also removing leftovers proxies from e.g. another branch with a different `config/toxiproxy.json`) to reset the internal state (the proxies defined in `config/toxiproxy.json`).
2. Then we create all the proxies we expect to be up via the `toxiproxy` API (from `config/toxiproxy.json`).

From there, we allow the boot which is going to establish network connections through `toxiproxy` ports (through their configs in `config/redis.json` etc.).

To me is the most reliable way to solve the problem.
