### PR TITLE
proxy: detect proxy conflict when starting the server

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -52,7 +52,6 @@ func (proxy *Proxy) Start() error {
 func (proxy *Proxy) server() {
 	ln, err := net.Listen("tcp", proxy.Listen)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{"upstream": proxy.Upstream, "err": err}).Error("Unable to start proxy server")
 		proxy.started <- err
 		return
 	}

--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -33,12 +33,6 @@ func (collection *ProxyCollection) Add(proxy *Proxy) error {
 		return fmt.Errorf("Proxy with name %s already exists", proxy.Name)
 	}
 
-	for _, otherProxy := range collection.proxies {
-		if proxy.Listen == otherProxy.Listen {
-			return fmt.Errorf("Proxy %s is already listening on %s", otherProxy.Name, proxy.Listen)
-		}
-	}
-
 	collection.proxies[proxy.Name] = proxy
 
 	return nil
@@ -107,7 +101,7 @@ func (collection *ProxyCollection) AddConfig(path string) {
 						"name":     proxy.Name,
 						"upstream": proxy.Upstream,
 						"listen":   proxy.Listen,
-					}).Fatal("Unable to start proxy to collection")
+					}).Error("Unable to start proxy server")
 				}
 			}
 		}

--- a/proxy_collection_test.go
+++ b/proxy_collection_test.go
@@ -39,24 +39,6 @@ func TestAddTwoProxiesToCollection(t *testing.T) {
 	}
 }
 
-func TestAddTwoProxiesWithSameProxyListen(t *testing.T) {
-	collection := NewProxyCollection()
-	proxy1 := NewTestProxy("test", "localhost:20000")
-
-	err := collection.Add(proxy1)
-	if err != nil {
-		t.Error("Expected to be able to add first proxy to collection")
-	}
-
-	proxy2 := NewTestProxy("test2", "localhost:20000")
-	proxy2.Listen = proxy1.Listen
-
-	err = collection.Add(proxy2)
-	if err == nil {
-		t.Error("Expected to not be able to add proxy with same listen")
-	}
-}
-
 func TestAddAndRemoveProxyFromCollection(t *testing.T) {
 	WithTCPProxy(t, func(conn net.Conn, response chan []byte, proxy *Proxy) {
 		collection := NewProxyCollection()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -76,6 +76,7 @@ func TestSimpleServer(t *testing.T) {
 func WithTCPProxy(t *testing.T, f func(proxy net.Conn, response chan []byte, proxyServer *Proxy)) {
 	WithTCPServer(t, func(upstream string, response chan []byte) {
 		proxy := NewTestProxy("test", upstream)
+		proxy.allocate()
 
 		proxy.Start()
 
@@ -145,5 +146,19 @@ func TestClosingProxyMultipleTimes(t *testing.T) {
 		proxy.Stop()
 		proxy.Stop()
 		proxy.Stop()
+	})
+}
+
+func TestStartTwoProxiesOnSameAddress(t *testing.T) {
+	WithTCPProxy(t, func(conn net.Conn, response chan []byte, proxy *Proxy) {
+		proxy2 := &Proxy{
+			Name:     "proxy_2",
+			Listen:   "localhost:20000",
+			Upstream: "localhost:3306",
+		}
+		proxy2.allocate()
+		if err := proxy2.Start(); err == nil {
+			t.Fatal("Expected an err back from start")
+		}
 	})
 }


### PR DESCRIPTION
In `proxy.go` we have:

``` go
func (proxy *Proxy) Start() error {
    go proxy.server()
    return <-proxy.started
}

func (proxy *Proxy) server() {
    ln, err := net.Listen("tcp", proxy.Listen)
    if err != nil {
        proxy.started <- err
        return
    }
// ....
}
```

Meaning if we get an error when starting the server (because of a port conflict, for example) we get the error back when calling `Start()`. As is done when loading the JSON config, or when creating proxies via the API. This removes the logic from `proxy_collection.go`, and just relies on this error instead.

Someone from @Shopify/resiliency please :+1: this.
