### PR TITLE
proxy: increase accept timeout to 50ms to decrease system CPU

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var AcceptTimeout = time.Millisecond
+var AcceptTimeout = 50 * time.Millisecond
 
 // Proxy represents the proxy in its entirity with all its links. The main
 // responsibility of Proxy is to accept new client and create Links between the


### PR DESCRIPTION
In development `toxiproxy` takes up quite a bit of CPU.

![screen shot 2014-09-16 at 20 58 16](https://cloud.githubusercontent.com/assets/97400/4297148/20065d02-3e06-11e4-8fa4-7d02568193bb.png)

With all this time spent in `select/accept4/epoll`:

![screen shot 2014-09-16 at 21 01 23](https://cloud.githubusercontent.com/assets/97400/4297170/8190f654-3e06-11e4-80e8-3648de813520.png)

I'm fairly sue it's due to the timeout of the `accept(2)` call. They have a fairly small timeout, because that's also the worst case time it takes to shut it down—which is done constantly during tests. When the timeout is reached, it goes to the start of the loop, checks if it's shutting down, if not, it goes back to a blocking `accept(2)` for another `AcceptTimeout`. This is fairly standard in Go (although not very nice).

In the future, we'll apply "toxics" to connections and won't start/stop servers and this won't matter anymore and we can set a 1s timeout or something which is only going to affect shutting down the proxy to take about 1s.

Review @graemej @csfrancis 
