### PR TITLE
config: remove loading json config

### DIFF
--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -1,12 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"sync"
-
-	"github.com/Sirupsen/logrus"
 )
 
 // ProxyCollection is a collection of proxies. It's the interface for anything
@@ -61,51 +57,6 @@ func (collection *ProxyCollection) Clear() error {
 	}
 
 	return nil
-}
-
-func (collection *ProxyCollection) AddConfig(path string) {
-	// Read the proxies from the JSON configuration file
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"err":    err,
-			"config": path,
-		}).Warn("No configuration file loaded")
-	} else {
-		var configProxies []Proxy
-
-		err := json.Unmarshal(data, &configProxies)
-		if err != nil {
-			logrus.WithFields(logrus.Fields{
-				"err":    err,
-				"config": configPath,
-			}).Warn("Unable to unmarshal configuration file")
-		}
-
-		for _, proxy := range configProxies {
-			// Allocate members since Proxy was created without the initializer
-			// (`NewProxy`) which normally takes care of this.
-			proxy.allocate()
-
-			err := collection.Add(&proxy)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"err":  err,
-					"name": proxy.Name,
-				}).Warn("Unable to add proxy to collection")
-			} else {
-				err := proxy.Start()
-				if err != nil {
-					logrus.WithFields(logrus.Fields{
-						"err":      err,
-						"name":     proxy.Name,
-						"upstream": proxy.Upstream,
-						"listen":   proxy.Listen,
-					}).Error("Unable to start proxy server")
-				}
-			}
-		}
-	}
 }
 
 // removeByName removes a proxy by its name. Its used from both #clear and

--- a/toxiproxy.go
+++ b/toxiproxy.go
@@ -4,12 +4,10 @@ import "flag"
 
 var Version = "0.0.1"
 
-var configPath string
 var apiHost string
 var apiPort string
 
 func init() {
-	flag.StringVar(&configPath, "config", "/etc/toxiproxy.json", "Path to JSON configuration file")
 	flag.StringVar(&apiHost, "host", "localhost", "Host for toxiproxy's API to listen on")
 	flag.StringVar(&apiPort, "port", "8474", "Port for toxiproxy's API to listen on")
 	flag.Parse()
@@ -17,8 +15,6 @@ func init() {
 
 func main() {
 	proxies := NewProxyCollection()
-	proxies.AddConfig(configPath)
-
 	server := NewServer(proxies)
 	server.Listen()
 }


### PR DESCRIPTION
We don't load the configuration of proxies from JSON anymore in CI, instead we make sure all the proxies [are present when we boot Rails](https://github.com/Shopify/shopify/blob/ea4e02e538230798a0e70683024193c0f5953014/lib/shopify/bootstrap.rb#L208-211).

Let's keep Toxiproxy as small as possible for now and remove this code (which is also buggy and doesn't have a test).

Review @graemej 
