### PR TITLE
Fix race when closing a proxy and modifying a toxic at the same time.

### DIFF
--- a/toxic_latency.go
+++ b/toxic_latency.go
@@ -31,15 +31,15 @@ func (t *LatencyToxic) delay() time.Duration {
 	return time.Duration(delay) * time.Millisecond
 }
 
-func (t *LatencyToxic) Pipe(stub *ToxicStub) bool {
+func (t *LatencyToxic) Pipe(stub *ToxicStub) {
 	for {
 		select {
 		case <-stub.interrupt:
-			return true
+			return
 		case buf := <-stub.input:
 			if buf == nil {
-				close(stub.output)
-				return false
+				stub.Close()
+				return
 			}
 			sleep := t.delay()
 			select {
@@ -47,7 +47,7 @@ func (t *LatencyToxic) Pipe(stub *ToxicStub) bool {
 				stub.output <- buf
 			case <-stub.interrupt:
 				stub.output <- buf // Don't drop any data on the floor
-				return true
+				return
 			}
 		}
 	}

--- a/toxic_noop.go
+++ b/toxic_noop.go
@@ -11,15 +11,15 @@ func (t *NoopToxic) IsEnabled() bool {
 	return true
 }
 
-func (t *NoopToxic) Pipe(stub *ToxicStub) bool {
+func (t *NoopToxic) Pipe(stub *ToxicStub) {
 	for {
 		select {
 		case <-stub.interrupt:
-			return true
+			return
 		case buf := <-stub.input:
 			if buf == nil {
-				close(stub.output)
-				return false
+				stub.Close()
+				return
 			}
 			stub.output <- buf
 		}

--- a/toxic_slow_close.go
+++ b/toxic_slow_close.go
@@ -17,20 +17,20 @@ func (t *SlowCloseToxic) IsEnabled() bool {
 	return t.Enabled
 }
 
-func (t *SlowCloseToxic) Pipe(stub *ToxicStub) bool {
+func (t *SlowCloseToxic) Pipe(stub *ToxicStub) {
 	for {
 		select {
 		case <-stub.interrupt:
-			return true
+			return
 		case buf := <-stub.input:
 			if buf == nil {
 				delay := time.Duration(t.Delay) * time.Millisecond
 				select {
 				case <-time.After(delay):
-					close(stub.output)
-					return false
+					stub.Close()
+					return
 				case <-stub.interrupt:
-					return true
+					return
 				}
 			}
 			stub.output <- buf

--- a/toxic_timeout.go
+++ b/toxic_timeout.go
@@ -18,18 +18,18 @@ func (t *TimeoutToxic) IsEnabled() bool {
 	return t.Enabled
 }
 
-func (t *TimeoutToxic) Pipe(stub *ToxicStub) bool {
+func (t *TimeoutToxic) Pipe(stub *ToxicStub) {
 	timeout := time.Duration(t.Timeout) * time.Millisecond
 	if timeout > 0 {
 		select {
 		case <-time.After(timeout):
-			close(stub.output)
-			return false
+			stub.Close()
+			return
 		case <-stub.interrupt:
-			return true
+			return
 		}
 	} else {
 		<-stub.interrupt
-		return true
+		return
 	}
 }


### PR DESCRIPTION
Fixes issue https://github.com/Shopify/toxiproxy/issues/22

```
See this CI run of toxiproxy-ruby for an example: https://circleci.com/gh/Shopify/toxiproxy-ruby/18
The build artifact toxiproxy.log contains the stack trace.

What I see happening is the proxy is being closed, and the toxic is being changed at the same time. The packet channel is being closed, but then a new toxic is being started, which will then try to close the channel again.
```

@Sirupsen @eapache 
