### PR TITLE
Fix race condition causing write to closed channel panic

### DIFF
--- a/link.go
+++ b/link.go
@@ -57,7 +57,7 @@ func (link *ToxicLink) Start(name string, source io.Reader, dest io.WriteCloser)
 		link.input.Close()
 	}()
 	for i, toxic := range link.toxics.chain {
-		go toxic.Pipe(link.stubs[i])
+		go link.stubs[i].Run(toxic)
 	}
 	go func() {
 		bytes, err := io.Copy(dest, link.output)
@@ -78,6 +78,6 @@ func (link *ToxicLink) Start(name string, source io.Reader, dest io.WriteCloser)
 // Replace the toxic at the specified index
 func (link *ToxicLink) SetToxic(toxic Toxic, index int) {
 	if link.stubs[index].Interrupt() {
-		go toxic.Pipe(link.stubs[index])
+		go link.stubs[index].Run(toxic)
 	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -9,8 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"gopkg.in/tomb.v1"
 )
+
+func init() {
+	logrus.SetLevel(logrus.FatalLevel)
+}
 
 func NewTestProxy(name, upstream string) *Proxy {
 	proxy := NewProxy()


### PR DESCRIPTION
@Sirupsen @graemej 

Fixes the following panic / race condition:
```
2015-04-28_02:00:30.60319 panic: send on closed channel
2015-04-28_02:00:30.60320 
2015-04-28_02:00:30.60320 goroutine 475 [running]:
2015-04-28_02:00:30.60322 main.(*LatencyToxic).Pipe(0xc20800b3a0, 0xc2082ad920)
2015-04-28_02:00:30.60323 	/Users/sirup/src/go/src/github.com/Shopify/toxiproxy/toxic_latency.go:53 +0x2b7
2015-04-28_02:00:30.60323 created by main.(*ToxicLink).Start
2015-04-28_02:00:30.60325 	/Users/sirup/src/go/src/github.com/Shopify/toxiproxy/link.go:60 +0x223
```
This only seems to happen with GOMAXPROCS > 1. Here's the flow that causes a panic:

```
1. Latency toxic is waiting for delay to finish an is interrupted (toxic_latency.go#L52)
2. Before inflight data is sent to output channel, the new toxic is started (toxic.go#L52 and link.go#L81)
3. The new toxic runs and encounters the end of stream, and closes the output (toxic_latency.go#L44 and toxic.go#L58)
4. The original toxic tries to send the inflight data on the closed channel and panics (toxic_latency.go#L53)
```