### PR TITLE
Change latency toxic to account for buffering

### DIFF
--- a/io_chan.go
+++ b/io_chan.go
@@ -5,23 +5,23 @@ import (
 	"time"
 )
 
-// Simulates a TCP packet by storing a slice of bytes with the receive timestmap
-type Packet struct {
+// Stores a slice of bytes with its receive timestmap
+type StreamChunk struct {
 	data      []byte
 	timestamp time.Time
 }
 
 // Implements the io.WriteCloser interface for a chan []byte
 type ChanWriter struct {
-	output chan<- *Packet
+	output chan<- *StreamChunk
 }
 
-func NewChanWriter(output chan<- *Packet) *ChanWriter {
+func NewChanWriter(output chan<- *StreamChunk) *ChanWriter {
 	return &ChanWriter{output}
 }
 
 func (c *ChanWriter) Write(buf []byte) (int, error) {
-	packet := &Packet{make([]byte, len(buf)), time.Now()}
+	packet := &StreamChunk{make([]byte, len(buf)), time.Now()}
 	copy(packet.data, buf) // Make a copy before sending it to the channel
 	c.output <- packet
 	return len(buf), nil
@@ -34,11 +34,11 @@ func (c *ChanWriter) Close() error {
 
 // Implements the io.Reader interface for a chan []byte
 type ChanReader struct {
-	input  <-chan *Packet
+	input  <-chan *StreamChunk
 	buffer []byte
 }
 
-func NewChanReader(input <-chan *Packet) *ChanReader {
+func NewChanReader(input <-chan *StreamChunk) *ChanReader {
 	return &ChanReader{input, []byte{}}
 }
 

--- a/io_chan.go
+++ b/io_chan.go
@@ -1,20 +1,29 @@
 package main
 
-import "io"
+import (
+	"io"
+	"time"
+)
+
+// Simulates a TCP packet by storing a slice of bytes with the receive timestmap
+type Packet struct {
+	data      []byte
+	timestamp time.Time
+}
 
 // Implements the io.WriteCloser interface for a chan []byte
 type ChanWriter struct {
-	output chan<- []byte
+	output chan<- *Packet
 }
 
-func NewChanWriter(output chan<- []byte) *ChanWriter {
+func NewChanWriter(output chan<- *Packet) *ChanWriter {
 	return &ChanWriter{output}
 }
 
 func (c *ChanWriter) Write(buf []byte) (int, error) {
-	buf2 := make([]byte, len(buf))
-	copy(buf2, buf) // Make a copy before sending it to the channel
-	c.output <- buf2
+	packet := &Packet{make([]byte, len(buf)), time.Now()}
+	copy(packet.data, buf) // Make a copy before sending it to the channel
+	c.output <- packet
 	return len(buf), nil
 }
 
@@ -25,11 +34,11 @@ func (c *ChanWriter) Close() error {
 
 // Implements the io.Reader interface for a chan []byte
 type ChanReader struct {
-	input  <-chan []byte
+	input  <-chan *Packet
 	buffer []byte
 }
 
-func NewChanReader(input <-chan []byte) *ChanReader {
+func NewChanReader(input <-chan *Packet) *ChanReader {
 	return &ChanReader{input, []byte{}}
 }
 
@@ -44,22 +53,24 @@ func (c *ChanReader) Read(out []byte) (int, error) {
 	} else if n > 0 {
 		// We have some data to return, so make the channel read optional
 		select {
-		case c.buffer = <-c.input:
-			if c.buffer == nil { // Stream was closed
+		case p := <-c.input:
+			if p == nil { // Stream was closed
+				c.buffer = nil
 				return n, io.EOF
 			}
-			n2 := copy(out[n:], c.buffer)
-			c.buffer = c.buffer[n2:]
+			n2 := copy(out[n:], p.data)
+			c.buffer = p.data[n2:]
 			return n + n2, nil
 		default:
 			return n, nil
 		}
 	}
-	c.buffer = <-c.input
-	if c.buffer == nil { // Stream was closed
+	p := <-c.input
+	if p == nil { // Stream was closed
+		c.buffer = nil
 		return 0, io.EOF
 	}
-	n2 := copy(out[n:], c.buffer)
-	c.buffer = c.buffer[n2:]
+	n2 := copy(out[n:], p.data)
+	c.buffer = p.data[n2:]
 	return n + n2, nil
 }

--- a/io_chan_test.go
+++ b/io_chan_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBasicReadWrite(t *testing.T) {
 	send := []byte("hello world")
-	c := make(chan []byte)
+	c := make(chan *Packet)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go writer.Write(send)
@@ -35,7 +35,7 @@ func TestBasicReadWrite(t *testing.T) {
 
 func TestReadMoreThanWrite(t *testing.T) {
 	send := []byte("hello world")
-	c := make(chan []byte)
+	c := make(chan *Packet)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go writer.Write(send)
@@ -62,7 +62,7 @@ func TestReadMoreThanWrite(t *testing.T) {
 
 func TestReadLessThanWrite(t *testing.T) {
 	send := []byte("hello world")
-	c := make(chan []byte)
+	c := make(chan *Packet)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go writer.Write(send)
@@ -99,7 +99,7 @@ func TestReadLessThanWrite(t *testing.T) {
 
 func TestMultiReadWrite(t *testing.T) {
 	send := []byte("hello world, this message is longer")
-	c := make(chan []byte)
+	c := make(chan *Packet)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go func() {
@@ -131,7 +131,7 @@ func TestMultiReadWrite(t *testing.T) {
 
 func TestMultiWriteWithCopy(t *testing.T) {
 	send := []byte("hello world, this message is longer")
-	c := make(chan []byte)
+	c := make(chan *Packet)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go func() {

--- a/io_chan_test.go
+++ b/io_chan_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBasicReadWrite(t *testing.T) {
 	send := []byte("hello world")
-	c := make(chan *Packet)
+	c := make(chan *StreamChunk)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go writer.Write(send)
@@ -35,7 +35,7 @@ func TestBasicReadWrite(t *testing.T) {
 
 func TestReadMoreThanWrite(t *testing.T) {
 	send := []byte("hello world")
-	c := make(chan *Packet)
+	c := make(chan *StreamChunk)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go writer.Write(send)
@@ -62,7 +62,7 @@ func TestReadMoreThanWrite(t *testing.T) {
 
 func TestReadLessThanWrite(t *testing.T) {
 	send := []byte("hello world")
-	c := make(chan *Packet)
+	c := make(chan *StreamChunk)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go writer.Write(send)
@@ -99,7 +99,7 @@ func TestReadLessThanWrite(t *testing.T) {
 
 func TestMultiReadWrite(t *testing.T) {
 	send := []byte("hello world, this message is longer")
-	c := make(chan *Packet)
+	c := make(chan *StreamChunk)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go func() {
@@ -131,7 +131,7 @@ func TestMultiReadWrite(t *testing.T) {
 
 func TestMultiWriteWithCopy(t *testing.T) {
 	send := []byte("hello world, this message is longer")
-	c := make(chan *Packet)
+	c := make(chan *StreamChunk)
 	writer := NewChanWriter(c)
 	reader := NewChanReader(c)
 	go func() {

--- a/link.go
+++ b/link.go
@@ -31,10 +31,10 @@ func NewToxicLink(proxy *Proxy, toxics *ToxicCollection) *ToxicLink {
 	}
 
 	// Initialize the link with ToxicStubs
-	last := make(chan *Packet)
+	last := make(chan *StreamChunk)
 	link.input = NewChanWriter(last)
 	for i := 0; i < len(link.stubs); i++ {
-		next := make(chan *Packet)
+		next := make(chan *StreamChunk)
 		link.stubs[i] = NewToxicStub(last, next)
 		last = next
 	}

--- a/link.go
+++ b/link.go
@@ -31,10 +31,10 @@ func NewToxicLink(proxy *Proxy, toxics *ToxicCollection) *ToxicLink {
 	}
 
 	// Initialize the link with ToxicStubs
-	last := make(chan []byte)
+	last := make(chan *Packet)
 	link.input = NewChanWriter(last)
 	for i := 0; i < len(link.stubs); i++ {
-		next := make(chan []byte)
+		next := make(chan *Packet)
 		link.stubs[i] = NewToxicStub(last, next)
 		last = next
 	}

--- a/toxic.go
+++ b/toxic.go
@@ -28,14 +28,14 @@ type Toxic interface {
 }
 
 type ToxicStub struct {
-	input     <-chan *Packet
-	output    chan<- *Packet
+	input     <-chan *StreamChunk
+	output    chan<- *StreamChunk
 	interrupt chan struct{}
 	running   chan struct{}
 	closed    chan struct{}
 }
 
-func NewToxicStub(input <-chan *Packet, output chan<- *Packet) *ToxicStub {
+func NewToxicStub(input <-chan *StreamChunk, output chan<- *StreamChunk) *ToxicStub {
 	return &ToxicStub{
 		interrupt: make(chan struct{}),
 		closed:    make(chan struct{}),

--- a/toxic.go
+++ b/toxic.go
@@ -28,14 +28,14 @@ type Toxic interface {
 }
 
 type ToxicStub struct {
-	input     <-chan []byte
-	output    chan<- []byte
+	input     <-chan *Packet
+	output    chan<- *Packet
 	interrupt chan struct{}
 	running   chan struct{}
 	closed    chan struct{}
 }
 
-func NewToxicStub(input <-chan []byte, output chan<- []byte) *ToxicStub {
+func NewToxicStub(input <-chan *Packet, output chan<- *Packet) *ToxicStub {
 	return &ToxicStub{
 		interrupt: make(chan struct{}),
 		closed:    make(chan struct{}),

--- a/toxic_latency.go
+++ b/toxic_latency.go
@@ -40,17 +40,17 @@ func (t *LatencyToxic) Pipe(stub *ToxicStub) {
 		select {
 		case <-stub.interrupt:
 			return
-		case p := <-stub.input:
-			if p == nil {
+		case c := <-stub.input:
+			if c == nil {
 				stub.Close()
 				return
 			}
-			sleep := t.delay() - time.Now().Sub(p.timestamp)
+			sleep := t.delay() - time.Now().Sub(c.timestamp)
 			select {
 			case <-time.After(sleep):
-				stub.output <- p
+				stub.output <- c
 			case <-stub.interrupt:
-				stub.output <- p // Don't drop any data on the floor
+				stub.output <- c // Don't drop any data on the floor
 				return
 			}
 		}

--- a/toxic_latency.go
+++ b/toxic_latency.go
@@ -40,17 +40,17 @@ func (t *LatencyToxic) Pipe(stub *ToxicStub) {
 		select {
 		case <-stub.interrupt:
 			return
-		case buf := <-stub.input:
-			if buf == nil {
+		case p := <-stub.input:
+			if p == nil {
 				stub.Close()
 				return
 			}
-			sleep := t.delay()
+			sleep := t.delay() - time.Now().Sub(p.timestamp)
 			select {
 			case <-time.After(sleep):
-				stub.output <- buf
+				stub.output <- p
 			case <-stub.interrupt:
-				stub.output <- buf // Don't drop any data on the floor
+				stub.output <- p // Don't drop any data on the floor
 				return
 			}
 		}

--- a/toxic_noop.go
+++ b/toxic_noop.go
@@ -18,12 +18,12 @@ func (t *NoopToxic) Pipe(stub *ToxicStub) {
 		select {
 		case <-stub.interrupt:
 			return
-		case p := <-stub.input:
-			if p == nil {
+		case c := <-stub.input:
+			if c == nil {
 				stub.Close()
 				return
 			}
-			stub.output <- p
+			stub.output <- c
 		}
 	}
 }

--- a/toxic_noop.go
+++ b/toxic_noop.go
@@ -18,12 +18,12 @@ func (t *NoopToxic) Pipe(stub *ToxicStub) {
 		select {
 		case <-stub.interrupt:
 			return
-		case buf := <-stub.input:
-			if buf == nil {
+		case p := <-stub.input:
+			if p == nil {
 				stub.Close()
 				return
 			}
-			stub.output <- buf
+			stub.output <- p
 		}
 	}
 }

--- a/toxic_slow_close.go
+++ b/toxic_slow_close.go
@@ -26,8 +26,8 @@ func (t *SlowCloseToxic) Pipe(stub *ToxicStub) {
 		select {
 		case <-stub.interrupt:
 			return
-		case buf := <-stub.input:
-			if buf == nil {
+		case p := <-stub.input:
+			if p == nil {
 				delay := time.Duration(t.Delay) * time.Millisecond
 				select {
 				case <-time.After(delay):
@@ -37,7 +37,7 @@ func (t *SlowCloseToxic) Pipe(stub *ToxicStub) {
 					return
 				}
 			}
-			stub.output <- buf
+			stub.output <- p
 		}
 	}
 }

--- a/toxic_slow_close.go
+++ b/toxic_slow_close.go
@@ -26,8 +26,8 @@ func (t *SlowCloseToxic) Pipe(stub *ToxicStub) {
 		select {
 		case <-stub.interrupt:
 			return
-		case p := <-stub.input:
-			if p == nil {
+		case c := <-stub.input:
+			if c == nil {
 				delay := time.Duration(t.Delay) * time.Millisecond
 				select {
 				case <-time.After(delay):
@@ -37,7 +37,7 @@ func (t *SlowCloseToxic) Pipe(stub *ToxicStub) {
 					return
 				}
 			}
-			stub.output <- p
+			stub.output <- c
 		}
 	}
 }

--- a/toxic_test.go
+++ b/toxic_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -87,7 +88,7 @@ func DoLatencyTest(t *testing.T, upLatency, downLatency *LatencyToxic) {
 		proxy.upToxics.SetToxicValue(upLatency)
 		proxy.downToxics.SetToxicValue(downLatency)
 
-		msg := []byte("hello world\n")
+		msg := []byte("hello world " + strings.Repeat("a", 32*1024) + "\n")
 
 		timer := time.Now()
 		_, err := conn.Write(msg)


### PR DESCRIPTION
@Sirupsen @pushrax 

Changes the latency toxic to better model network latency.

Previously the latency toxic would insert a delay after each "packet", and these would accumulate for large amounts of data.
This PR changes toxiproxy to calculate the delay based on the receive time of the "packet".