### PR TITLE
Remove /toxics endpoint in favour of /proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0 (Unreleased)
+
+* Remove /toxics endpoint in favour of /proxies
+
 # 1.0.3
 
 * Rename Go library package to Toxiproxy from Client

--- a/README.md
+++ b/README.md
@@ -336,9 +336,8 @@ back to `true` to reenable it.
 
 All endpoints are JSON.
 
- - **GET /proxies** - List existing proxies
+ - **GET /proxies** - List existing proxies and their toxics
  - **POST /proxies** - Create a new proxy
- - **GET /toxics** - List existing proxies with toxics included
  - **GET /proxies/{proxy}** - Show the proxy with both its upstream and downstream toxics
  - **POST /proxies/{proxy}** - Update a proxy's fields
  - **DELETE /proxies/{proxy}** - Delete an existing proxy

--- a/api_test.go
+++ b/api_test.go
@@ -61,7 +61,7 @@ func TestCreateProxy(t *testing.T) {
 	})
 }
 
-func TestIndexWithProxies(t *testing.T) {
+func TestIndexWithToxics(t *testing.T) {
 	WithServer(t, func(addr string) {
 		err := testProxy.Create()
 		if err != nil {
@@ -70,25 +70,7 @@ func TestIndexWithProxies(t *testing.T) {
 
 		proxies, err := client.Proxies()
 		if err != nil {
-			t.Fatal("Failed listing proxies: ", err)
-		}
-
-		if len(proxies) == 0 {
-			t.Fatal("Expected new proxy in list")
-		}
-	})
-}
-
-func TestIndexWithToxics(t *testing.T) {
-	WithServer(t, func(addr string) {
-		err := testProxy.Create()
-		if err != nil {
-			t.Fatal("Unable to create proxy")
-		}
-
-		proxies, err := client.Toxics()
-		if err != nil {
-			t.Fatal("Error listing toxics: ", err)
+			t.Fatal("Error listing proxies: ", err)
 		}
 
 		if len(proxies) == 0 {

--- a/client/client.go
+++ b/client/client.go
@@ -37,7 +37,7 @@ func NewClient(endpoint string) *Client {
 	return &Client{endpoint: endpoint}
 }
 
-// Proxies returns a map with all the proxies.
+// Proxies returns a map with all the proxies and their toxics.
 func (client *Client) Proxies() (map[string]*Proxy, error) {
 	resp, err := http.Get(client.endpoint + "/proxies")
 	if err != nil {
@@ -191,22 +191,6 @@ func (proxy *Proxy) SetToxic(name string, direction string, fields Fields) (map[
 	}
 
 	return toxics, nil
-}
-
-// Toxics lists all proxies and toxics.
-func (client *Client) Toxics() (map[string]*Proxy, error) {
-	resp, err := http.Get(client.endpoint + "/toxics")
-	if err != nil {
-		return nil, err
-	}
-
-	proxies := make(map[string]*Proxy)
-	err = json.NewDecoder(resp.Body).Decode(&proxies)
-	if err != nil {
-		return nil, err
-	}
-
-	return proxies, nil
 }
 
 // ResetState resets the state of all proxies and toxics in Toxiproxy.


### PR DESCRIPTION
@Sirupsen 

Implements changes proposed in https://github.com/Shopify/toxiproxy/issues/36

Will have to look at what uses this endpoint. I think it may just be turbobar.
The ruby client does not use this endpoint.