### PR TITLE
Change error handling, and check for blank proxy names

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net"
 	"net/http"
@@ -100,6 +101,15 @@ func (server *server) ProxyCreate(response http.ResponseWriter, request *http.Re
 	err := json.NewDecoder(request.Body).Decode(&input)
 	if err != nil {
 		http.Error(response, server.apiError(err, http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	if len(input.Name) < 1 {
+		http.Error(response, server.apiError(errors.New("Missing required field: name"), http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+	if len(input.Upstream) < 1 {
+		http.Error(response, server.apiError(errors.New("Missing required field: name"), http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 

--- a/api.go
+++ b/api.go
@@ -109,7 +109,7 @@ func (server *server) ProxyCreate(response http.ResponseWriter, request *http.Re
 		return
 	}
 	if len(input.Upstream) < 1 {
-		http.Error(response, server.apiError(errors.New("Missing required field: name"), http.StatusBadRequest), http.StatusBadRequest)
+		http.Error(response, server.apiError(errors.New("Missing required field: upstream"), http.StatusBadRequest), http.StatusBadRequest)
 		return
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -61,6 +61,18 @@ func TestCreateProxy(t *testing.T) {
 	})
 }
 
+func TestCreateProxyBlankName(t *testing.T) {
+	WithServer(t, func(addr string) {
+		blankProxy := client.NewProxy(&tclient.Proxy{})
+		err := blankProxy.Create()
+		if err == nil {
+			t.Fatal("Expected error creating proxy, got nil")
+		} else if err.Error() != "Create: HTTP 400: Missing required field: name" {
+			t.Fatal("Expected different error creating proxy:", err)
+		}
+	})
+}
+
 func TestIndexWithToxics(t *testing.T) {
 	WithServer(t, func(addr string) {
 		err := testProxy.Create()

--- a/api_test.go
+++ b/api_test.go
@@ -73,6 +73,18 @@ func TestCreateProxyBlankName(t *testing.T) {
 	})
 }
 
+func TestCreateProxyBlankUpstream(t *testing.T) {
+	WithServer(t, func(addr string) {
+		blankProxy := client.NewProxy(&tclient.Proxy{Name: "test"})
+		err := blankProxy.Create()
+		if err == nil {
+			t.Fatal("Expected error creating proxy, got nil")
+		} else if err.Error() != "Create: HTTP 400: Missing required field: upstream" {
+			t.Fatal("Expected different error creating proxy:", err)
+		}
+	})
+}
+
 func TestIndexWithToxics(t *testing.T) {
 	WithServer(t, func(addr string) {
 		err := testProxy.Create()


### PR DESCRIPTION
Fixes https://github.com/Shopify/toxiproxy/issues/51 and gives better errors back form the go api

@Sirupsen 