### PR TITLE
cli: initial commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Add a Toxic and Toxics type for the Go client
+* Add basic CLI
 
 # 1.1.0
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"github.com/Shopify/toxiproxy/client"
+	"github.com/codegangsta/cli"
+	"sort"
+
+	"fmt"
+	"os"
+)
+
+const (
+	redColor    = "\x1b[31m"
+	greenColor  = "\x1b[32m"
+	yellowColor = "\x1b[33m"
+	blueColor   = "\x1b[34m"
+	grayColor   = "\x1b[37m"
+	noColor     = "\x1b[0m"
+)
+
+func main() {
+	toxiproxyClient := toxiproxy.NewClient("http://localhost:8474")
+
+	app := cli.NewApp()
+	app.Name = "Toxiproxy"
+	app.Usage = "Simulate network and system conditions"
+	app.Commands = []cli.Command{
+		{
+			Name:    "list",
+			Aliases: []string{"l", "li", "ls"},
+			Usage:   "List all proxies",
+			Action: func(c *cli.Context) {
+				proxies, err := toxiproxyClient.Proxies()
+				if err != nil {
+					fmt.Println("Failed to retrieve proxies: ", err)
+					os.Exit(1)
+				}
+
+				var proxyNames []string
+				for proxyName := range proxies {
+					proxyNames = append(proxyNames, proxyName)
+				}
+				sort.Strings(proxyNames)
+
+				fmt.Fprintf(os.Stderr, "%sListen\t\t%sUpstream\t%sName%s\n", blueColor, yellowColor, greenColor, noColor)
+				fmt.Fprintf(os.Stderr, "%s================================================================================%s\n", grayColor, noColor)
+
+				for _, proxyName := range proxyNames {
+					proxy := proxies[proxyName]
+					fmt.Printf("%s%s\t%s%s\t%s%s%s\n", blueColor, proxy.Listen, yellowColor, proxy.Upstream, enabledColor(proxy.Enabled), proxy.Name, noColor)
+				}
+			},
+		},
+		{
+			Name:    "inspect",
+			Aliases: []string{"i", "ins"},
+			Usage:   "Inspect a single proxy",
+			Action: func(c *cli.Context) {
+				proxyName := c.Args().First()
+
+				proxy, err := toxiproxyClient.Proxy(proxyName)
+				if err != nil {
+					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+					os.Exit(1)
+				}
+
+				// TODO It would be cool to include the enabled toxics in the pipe
+				// rendering --L-SC-> for latency + slow close enabled
+				fmt.Printf("%s%s%s\n", enabledColor(proxy.Enabled), proxy.Name, noColor)
+				fmt.Printf("%s%s %s---> %s%s%s\n\n", blueColor, proxy.Listen, grayColor, yellowColor, proxy.Upstream, noColor)
+
+				listToxics(proxy.ToxicsUpstream, "upstream")
+				fmt.Println()
+				listToxics(proxy.ToxicsDownstream, "downstream")
+			},
+		},
+		{
+			Name:    "toggle",
+			Usage:   "Toggle enabled status on a proxy",
+			Aliases: []string{"tog"},
+			Action: func(c *cli.Context) {
+				proxyName := c.Args().First()
+
+				proxy, err := toxiproxyClient.Proxy(proxyName)
+				if err != nil {
+					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+					os.Exit(1)
+				}
+
+				proxy.Enabled = !proxy.Enabled
+
+				err = proxy.Save()
+				if err != nil {
+					fmt.Printf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
+					os.Exit(1)
+				}
+
+				fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
+			},
+		},
+	}
+
+	app.Run(os.Args)
+}
+
+func enabledColor(enabled bool) string {
+	if enabled {
+		return "\x1b[32m"
+	}
+
+	return "\x1b[31m"
+}
+
+func enabledText(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+
+	return "disabled"
+}
+
+func listToxics(toxics toxiproxy.Toxics, direction string) {
+	for name, toxic := range toxics {
+		fmt.Printf("%s%s direction=%s", enabledColor(toxic["enabled"].(bool)), name, direction)
+
+		for property, value := range toxic {
+			fmt.Printf(" %s=", property)
+			fmt.Print(value)
+		}
+		fmt.Println()
+	}
+}


### PR DESCRIPTION
Adds a simple V1 of a CLI that enables you to list proxies and toggle their enabled flag. Really nice to get an overview of things and play around with it. Will support Toxics later, and then we'll figure out how to distribute it. It could be a separate binary with a name like `toxiproxyctl` or it could be part of the main one and then daemon just becomes a command (and it starts by default to be backwards compatible).

This is really handy for quick and dirty testing yourself, or for black-box resiliency testing. A more friendly interface would be a web app, that can be done as well. It's remarkably easy with the Go client.

![screen shot 2015-05-18 at 16 13 52](https://cloud.githubusercontent.com/assets/97400/7689259/e5c7b4be-fd78-11e4-8bb1-13a670213f3e.png)
![screen shot 2015-05-18 at 16 13 34](https://cloud.githubusercontent.com/assets/97400/7689260/e5c8a928-fd78-11e4-962b-22d325528aac.png)
![screen shot 2015-05-18 at 16 13 24](https://cloud.githubusercontent.com/assets/97400/7689258/e5c78318-fd78-11e4-818a-0a8f0a91fe80.png)




@xthexder 
