### PR TITLE
Add toxic slicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add a Toxic and Toxics type for the Go client
 * Add `Dockerfile`
 * Fix latency toxic limiting bandwidth #67
+* Add Slicer toxic
 
 # 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -334,6 +334,19 @@ Fields:
  - `enabled`: true/false
  - `timeout`: time in milliseconds
 
+#### slicer
+
+Slices TCP data up into small bits, optionally adding a delay between each
+sliced "packet".
+
+Fields:
+
+ - `enabled`: true/false
+ - `averageSize`: size in bytes of an average packet
+ - `sizeVariation`: variation in bytes of an average packet (should be smaller than averageSize)
+ - `delay`: time in microseconds to delay each packet by
+
+
 ### HTTP API
 
 All communication with the Toxiproxy daemon from the client happens through the

--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ sliced "packet".
 Fields:
 
  - `enabled`: true/false
- - `averageSize`: size in bytes of an average packet
- - `sizeVariation`: variation in bytes of an average packet (should be smaller than averageSize)
+ - `average_size`: size in bytes of an average packet
+ - `size_variation`: variation in bytes of an average packet (should be smaller than averageSize)
  - `delay`: time in microseconds to delay each packet by
 
 

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -22,6 +22,7 @@ func NewToxicCollection(proxy *Proxy) *ToxicCollection {
 		new(SlowCloseToxic),
 		new(LatencyToxic),
 		new(BandwidthToxic),
+		new(SlicerToxic),
 		new(TimeoutToxic),
 	}
 

--- a/toxic_slicer.go
+++ b/toxic_slicer.go
@@ -10,10 +10,10 @@ import (
 type SlicerToxic struct {
 	Enabled bool `json:"enabled"`
 	// Average number of bytes to slice at
-	AverageSize int `json:"averageSize"`
+	AverageSize int `json:"average_size"`
 	// +/- bytes to vary sliced amounts. Must be less than
 	// the average size
-	SizeVariation int `json:"sizeVariation"`
+	SizeVariation int `json:"size_variation"`
 	// Microseconds to delay each packet. May be useful since there's
 	// usually some kind of buffering of network data
 	Delay int `json:"delay"`
@@ -54,9 +54,9 @@ func (t *SlicerToxic) chunk(start int, end int) []int {
 	left := t.chunk(start, mid)
 	right := t.chunk(mid, end)
 
-	out := make([]int, len(left)+len(right))
-	copy(out, left)
-	copy(out[len(left):], right)
+	out := make([]int, 0, len(left)+len(right))
+	out = append(out, left...)
+	out = append(out, right...)
 
 	return out
 }
@@ -73,9 +73,9 @@ func (t *SlicerToxic) Pipe(stub *ToxicStub) {
 			}
 
 			chunks := t.chunk(0, len(c.data))
-			for i := 0; i < len(chunks); i += 2 {
+			for i := 1; i < len(chunks); i += 2 {
 				stub.output <- &StreamChunk{
-					data:      c.data[chunks[i]:chunks[i+1]],
+					data:      c.data[chunks[i-1]:chunks[i]],
 					timestamp: c.timestamp,
 				}
 

--- a/toxic_slicer.go
+++ b/toxic_slicer.go
@@ -81,6 +81,10 @@ func (t *SlicerToxic) Pipe(stub *ToxicStub) {
 
 				select {
 				case <-stub.interrupt:
+					stub.output <- &StreamChunk{
+						data:      c.data[chunks[i]:],
+						timestamp: c.timestamp,
+					}
 					return
 				case <-time.After(time.Duration(t.Delay) * time.Microsecond):
 				}

--- a/toxic_slicer.go
+++ b/toxic_slicer.go
@@ -50,7 +50,7 @@ func (t *SlicerToxic) chunk(start int, end int) []int {
 
 	// +1 in the size variation to offset favoring of smaller
 	// numbers by integer division
-	mid := start + (end-start)/2 + (rand.Intn(t.SizeVariation*2+1) - t.SizeVariation)
+	mid := start + (end-start)/2 + (rand.Intn(t.SizeVariation*2) - t.SizeVariation) + rand.Intn(1)
 	left := t.chunk(start, mid)
 	right := t.chunk(mid, end)
 

--- a/toxic_slicer.go
+++ b/toxic_slicer.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"math/rand"
+	"time"
+)
+
+// The SlicerToxic slices data into multiple smaller packets
+// to simulate real-world TCP behaviour.
+type SlicerToxic struct {
+	Enabled bool `json:"enabled"`
+	// Average number of bytes to slice at
+	AverageSize int `json:"averageSize"`
+	// +/- bytes to vary sliced amounts. Must be less than
+	// the average size
+	SizeVariation int `json:"sizeVariation"`
+	// Microseconds to delay each packet. May be useful since there's
+	// usually some kind of buffering of network data
+	Delay int `json:"delay"`
+}
+
+func (t *SlicerToxic) Name() string {
+	return "slicer"
+}
+
+func (t *SlicerToxic) IsEnabled() bool {
+	return t.Enabled
+}
+
+func (t *SlicerToxic) SetEnabled(enabled bool) {
+	t.Enabled = enabled
+}
+
+// Returns a list of chunk offsets to slice up a packet of the
+// given total size. For example, for a size of 100, output might be:
+//
+//     []int{0, 18, 18, 43, 43, 67, 67, 77, 77, 100}
+//           ^---^  ^----^  ^----^  ^----^  ^-----^
+//
+// This tries to get fairly evenly-varying chunks (no tendency
+// to have a small/large chunk at the start/end).
+func (t *SlicerToxic) chunk(start int, end int) []int {
+	// Base case:
+	// If the size is within the random varation, _or already
+	// less than the average size_, just return it.
+	// Otherwise split the chunk in about two, and recurse.
+	if (end-start)-t.AverageSize <= t.SizeVariation {
+		return []int{start, end}
+	}
+
+	// +1 in the size variation to offset favoring of smaller
+	// numbers by integer division
+	mid := start + (end-start)/2 + (rand.Intn(t.SizeVariation*2+1) - t.SizeVariation)
+	left := t.chunk(start, mid)
+	right := t.chunk(mid, end)
+
+	out := make([]int, len(left)+len(right))
+	copy(out, left)
+	copy(out[len(left):], right)
+
+	return out
+}
+
+func (t *SlicerToxic) Pipe(stub *ToxicStub) {
+	for {
+		select {
+		case <-stub.interrupt:
+			return
+		case c := <-stub.input:
+			if c == nil {
+				stub.Close()
+				return
+			}
+
+			chunks := t.chunk(0, len(c.data))
+			for i := 0; i < len(chunks); i += 2 {
+				stub.output <- &StreamChunk{
+					data:      c.data[chunks[i]:chunks[i+1]],
+					timestamp: c.timestamp,
+				}
+
+				select {
+				case <-stub.interrupt:
+					return
+				case <-time.After(time.Duration(t.Delay) * time.Microsecond):
+				}
+			}
+		}
+	}
+}

--- a/toxic_slicer.go
+++ b/toxic_slicer.go
@@ -54,11 +54,7 @@ func (t *SlicerToxic) chunk(start int, end int) []int {
 	left := t.chunk(start, mid)
 	right := t.chunk(mid, end)
 
-	out := make([]int, 0, len(left)+len(right))
-	out = append(out, left...)
-	out = append(out, right...)
-
-	return out
+	return append(left, right...)
 }
 
 func (t *SlicerToxic) Pipe(stub *ToxicStub) {


### PR DESCRIPTION
When working on relative low-level network applications/clients, it's easy to assume that TCP data will always some in nice grouped "packets" that have all the data you need in them, rather than viewing the connection as a stream. When working locally that may even be its apparent behaviour, but over real-world network connections that's certainly not something that can be relied upon.

This PR adds a "slicer" filter which takes data and slices it up into nice little random chunks before sending them out. The slider also includes a simple delay option, to bypass buffering behaviour that could otherwise nullify the sliced bytes.