### PR TITLE
Fix latency bandwidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add a Toxic and Toxics type for the Go client
 * Add `Dockerfile`
+* Fix latency toxic limiting bandwidth #67
 
 # 1.1.0
 

--- a/link.go
+++ b/link.go
@@ -31,10 +31,10 @@ func NewToxicLink(proxy *Proxy, toxics *ToxicCollection) *ToxicLink {
 	}
 
 	// Initialize the link with ToxicStubs
-	last := make(chan *StreamChunk)
+	last := make(chan *StreamChunk, 1024)
 	link.input = NewChanWriter(last)
 	for i := 0; i < len(link.stubs); i++ {
-		next := make(chan *StreamChunk)
+		next := make(chan *StreamChunk, 1024)
 		link.stubs[i] = NewToxicStub(last, next)
 		last = next
 	}


### PR DESCRIPTION
Due to the blocking channels inbetween toxics, the latency toxic was causing TCP reads to block, and thus slowing down the the maximum bandwidth of the toxic.
This change allows some buffering between toxics, which fixes the issue (until the buffer fills up, which will only happen at extremely high throughput + high latency configurations)

@Sirupsen @pushrax for review