### PR TITLE
Added a windows build to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,13 @@ GODEP_PATH=$(shell pwd)/Godeps/_workspace
 ORIGINAL_PATH=$(shell echo $(GOPATH))
 COMBINED_GOPATH=$(GODEP_PATH):$(ORIGINAL_PATH)
 
-.PHONY: packages deb test linux darwin
+.PHONY: packages deb test linux darwin windows
 
-all: deb linux darwin docker
+all: deb linux darwin windows docker
 deb: $(DEB)
 darwin: tmp/build/toxiproxy-darwin-amd64 
 linux: tmp/build/toxiproxy-linux-amd64
+windows: tmp/build/toxiproxy-windows-amd64.exe
 
 build:
 	GOPATH=$(COMBINED_GOPATH) go build -o toxiproxy
@@ -27,6 +28,9 @@ tmp/build/toxiproxy-linux-amd64:
 
 tmp/build/toxiproxy-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -o $(@)
+
+tmp/build/toxiproxy-windows-amd64.exe:
+	GOOS=windows GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -o $(@)
 
 docker:
 	docker build --tag="shopify/toxiproxy:$(VERSION)" .

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ $ brew tap shopify/shopify
 $ brew install toxiproxy
 ```
 
+**Windows**
+
+Toxiproxy for Windows is available for download at https://github.com/Shopify/toxiproxy/releases/download/v1.2.1/toxiproxy-windows-amd64.exe
+
 **Docker**
 
 Toxiproxy is available on [Docker Hub](https://registry.hub.docker.com/u/shopify/toxiproxy/).


### PR DESCRIPTION
 It would be really useful for me to be able to link to an official windows executable for the [.net client](https://github.com/mdevilliers/toxiproxy).

To aid this I've added a build to the makefile to produce an windows exe for amd64.

To enable cross compilation of windows on linux, darwin follow the instructions at https://github.com/golang/go/wiki/WindowsCrossCompiling. 

then run make.bash enabling windows and amd64

```
cd $GOROOT/src
GOOS=windows GOARCH=amd64 ./make.bash --no-clean
```

Mark
