### PR TITLE
Fix slicer test race / deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix slicer toxic testing race condition #71
+
 # 1.2.1
 
 * Fix proxy name conflicts leaking an open port #69

--- a/toxic_test.go
+++ b/toxic_test.go
@@ -455,8 +455,14 @@ func TestSlicerToxic(t *testing.T) {
 		done <- true
 	}()
 	defer func() {
-		input <- nil
-		<-done
+		close(input)
+		for {
+			select {
+			case <-done:
+				return
+			case <-output:
+			}
+		}
 	}()
 
 	input <- &StreamChunk{data: data}
@@ -469,7 +475,7 @@ L:
 		case c := <-output:
 			reads++
 			buf = append(buf, c.data...)
-		case <-time.After(5 * time.Millisecond):
+		case <-time.After(10 * time.Millisecond):
 			break L
 		}
 	}


### PR DESCRIPTION
@Sirupsen @pushrax 

If the timeout is hit, the tests will hang on `output <- data` inside the toxic, this fixes that.
I also increased the timeout slightly since I ran into it once when my VM was running a little slow.

cc @connor4312 