### PR TITLE
Make ChanReader interruptable

### DIFF
--- a/stream/io_chan.go
+++ b/stream/io_chan.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"fmt"
 	"io"
 	"time"
 )
@@ -28,6 +29,7 @@ func NewChanWriter(output chan<- *StreamChunk) *ChanWriter {
 	return &ChanWriter{output}
 }
 
+// Write `buf` as a StreamChunk to the channel
 func (c *ChanWriter) Write(buf []byte) (int, error) {
 	packet := &StreamChunk{make([]byte, len(buf)), time.Now()}
 	copy(packet.Data, buf) // Make a copy before sending it to the channel
@@ -35,6 +37,7 @@ func (c *ChanWriter) Write(buf []byte) (int, error) {
 	return len(buf), nil
 }
 
+// Close the output channel
 func (c *ChanWriter) Close() error {
 	close(c.output)
 	return nil
@@ -42,14 +45,24 @@ func (c *ChanWriter) Close() error {
 
 // Implements the io.Reader interface for a chan []byte
 type ChanReader struct {
-	input  <-chan *StreamChunk
-	buffer []byte
+	input     <-chan *StreamChunk
+	interrupt <-chan struct{}
+	buffer    []byte
 }
+
+var ErrInterrupted = fmt.Errorf("read interrupted by channel")
 
 func NewChanReader(input <-chan *StreamChunk) *ChanReader {
-	return &ChanReader{input, []byte{}}
+	return &ChanReader{input, make(chan struct{}), []byte{}}
 }
 
+// Specify a channel that can interrupt a read if it is blocking.
+func (c *ChanReader) SetInterrupt(interrupt <-chan struct{}) {
+	c.interrupt = interrupt
+}
+
+// Read from the channel into `out`. This will block until data is available,
+// and can be interrupted with a channel using `SetInterrupt()`
 func (c *ChanReader) Read(out []byte) (int, error) {
 	if c.buffer == nil {
 		return 0, io.EOF
@@ -73,7 +86,13 @@ func (c *ChanReader) Read(out []byte) (int, error) {
 			return n, nil
 		}
 	}
-	p := <-c.input
+	var p *StreamChunk
+	select {
+	case p = <-c.input:
+	case <-c.interrupt:
+		c.buffer = c.buffer[:0]
+		return n, ErrInterrupted
+	}
 	if p == nil { // Stream was closed
 		c.buffer = nil
 		return 0, io.EOF

--- a/stream/io_chan.go
+++ b/stream/io_chan.go
@@ -29,7 +29,8 @@ func NewChanWriter(output chan<- *StreamChunk) *ChanWriter {
 	return &ChanWriter{output}
 }
 
-// Write `buf` as a StreamChunk to the channel
+// Write `buf` as a StreamChunk to the channel. The full buffer is always written, and error
+// will always be nil. Calling `Write()` after closing the channel will panic.
 func (c *ChanWriter) Write(buf []byte) (int, error) {
 	packet := &StreamChunk{make([]byte, len(buf)), time.Now()}
 	copy(packet.Data, buf) // Make a copy before sending it to the channel
@@ -62,7 +63,8 @@ func (c *ChanReader) SetInterrupt(interrupt <-chan struct{}) {
 }
 
 // Read from the channel into `out`. This will block until data is available,
-// and can be interrupted with a channel using `SetInterrupt()`
+// and can be interrupted with a channel using `SetInterrupt()`. If the read
+// was interrupted, `ErrInterrupted` will be returned.
 func (c *ChanReader) Read(out []byte) (int, error) {
 	if c.buffer == nil {
 		return 0, io.EOF


### PR DESCRIPTION
In order for `ChanReader` and `ChanWriter` to be used inside toxics, they need be interruptable.
This PR allows them to take the toxic's `interrupt` channel as a parameter, and unblock and reads.

@Sirupsen @eapache 