### PR TITLE
Clean up Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.4
 
 ADD . /app/src/github.com/Shopify/toxiproxy
-RUN cd /app/src/github.com/Shopify/toxiproxy && GOPATH=/app/src/github.com/Shopify/toxiproxy/Godeps/_workspace:/app go build -o /app/toxiproxy ./cmd
+RUN cd /app/src/github.com/Shopify/toxiproxy && GOPATH=/app/src/github.com/Shopify/toxiproxy/Godeps/_workspace:/app go build -ldflags="-X github.com/Shopify/toxiproxy.Version $(cat VERSION)" -o /app/toxiproxy ./cmd
 
 EXPOSE 8474
 ENTRYPOINT ["/app/toxiproxy"]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COMBINED_GOPATH=$(GODEP_PATH):$(ORIGINAL_PATH)
 .PHONY: packages deb test linux darwin windows
 
 build:
-	GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version git-`git rev-parse --short HEAD`" -o toxiproxy ./cmd
+	GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version git-$(git rev-parse --short HEAD)" -o toxiproxy ./cmd
 
 all: deb linux darwin windows
 deb: $(DEB)

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,15 @@ COMBINED_GOPATH=$(GODEP_PATH):$(ORIGINAL_PATH)
 
 .PHONY: packages deb test linux darwin windows
 
-all: version deb linux darwin windows docker
+build:
+	GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version git-`git rev-parse --short HEAD`" -o toxiproxy ./cmd
+
+all: deb linux darwin windows
 deb: $(DEB)
 darwin: tmp/build/toxiproxy-darwin-amd64
 linux: tmp/build/toxiproxy-linux-amd64
 windows: tmp/build/toxiproxy-windows-amd64.exe
-
-build:
-	GOPATH=$(COMBINED_GOPATH) go build -o toxiproxy ./cmd
+release: all docker
 
 clean:
 	rm tmp/build/*
@@ -23,17 +24,14 @@ clean:
 test:
 	GOMAXPROCS=4 GOPATH=$(COMBINED_GOPATH) go test -v -race ./...
 
-version:
-	sed -i "s/Version = \"[^\"]*\"/Version = \"$(VERSION)\"/" version.go
-
 tmp/build/toxiproxy-linux-amd64:
-	GOOS=linux GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -o $(@) ./cmd
+	GOOS=linux GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version $(VERSION)" -o $(@) ./cmd
 
 tmp/build/toxiproxy-darwin-amd64:
-	GOOS=darwin GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -o $(@) ./cmd
+	GOOS=darwin GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version $(VERSION)" -o $(@) ./cmd
 
 tmp/build/toxiproxy-windows-amd64.exe:
-	GOOS=windows GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -o $(@) ./cmd
+	GOOS=windows GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version $(VERSION)" -o $(@) ./cmd
 
 docker:
 	docker build --tag="shopify/toxiproxy:$(VERSION)" .

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ For example, `shopify_test_redis_master` or `shopify_development_mysql_1`.
 ### Release
 
 1. Update `CHANGELOG.md`
-2. Bump `VERSION` and `toxiproxy.go`
+2. Bump `VERSION`
 3. Change versions in `README.md`
 4. Commit
 5. Tag

--- a/version.go
+++ b/version.go
@@ -1,4 +1,3 @@
 package toxiproxy
 
-//go:generate make version
-var Version = "1.2.1"
+var Version = "git"


### PR DESCRIPTION
Instead of using a hacky sed script to write the `VERSION` file into `version.go`, this uses the `-X` parameter of the linker.
I also made the default operation of `make` to be a dev build instead of a full release.

Dev builds will now show up as version `git-<sha>` instead of the previous release. If just `go build` is used, the version will be just `git`

@Sirupsen 