### PR TITLE
Fix toxic marhsaling and toxicity updating

### DIFF
--- a/api.go
+++ b/api.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/Shopify/toxiproxy/toxics"
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 )
@@ -231,7 +230,7 @@ func (server *ApiServer) ToxicCreate(response http.ResponseWriter, request *http
 		return
 	}
 
-	data, err := json.Marshal(toxic)
+	data, err := json.Marshal(toxic.GetMap())
 	if apiError(response, err) {
 		return
 	}
@@ -257,7 +256,7 @@ func (server *ApiServer) ToxicShow(response http.ResponseWriter, request *http.R
 		return
 	}
 
-	data, err := json.Marshal(toxic)
+	data, err := json.Marshal(toxic.GetMap())
 	if apiError(response, err) {
 		return
 	}
@@ -282,7 +281,7 @@ func (server *ApiServer) ToxicUpdate(response http.ResponseWriter, request *http
 		return
 	}
 
-	data, err := json.Marshal(toxic)
+	data, err := json.Marshal(toxic.GetMap())
 	if apiError(response, err) {
 		return
 	}
@@ -376,7 +375,7 @@ func apiError(resp http.ResponseWriter, err error) bool {
 
 func proxyWithToxics(proxy *Proxy) (result struct {
 	*Proxy
-	Toxics map[string]toxics.Toxic `json:"toxics"`
+	Toxics map[string]interface{} `json:"toxics"`
 }) {
 	result.Proxy = proxy
 	result.Toxics = proxy.Toxics.GetToxicMap()

--- a/api.go
+++ b/api.go
@@ -230,7 +230,7 @@ func (server *ApiServer) ToxicCreate(response http.ResponseWriter, request *http
 		return
 	}
 
-	data, err := json.Marshal(toxic.GetMap())
+	data, err := json.Marshal(toxic)
 	if apiError(response, err) {
 		return
 	}
@@ -256,7 +256,7 @@ func (server *ApiServer) ToxicShow(response http.ResponseWriter, request *http.R
 		return
 	}
 
-	data, err := json.Marshal(toxic.GetMap())
+	data, err := json.Marshal(toxic)
 	if apiError(response, err) {
 		return
 	}
@@ -281,7 +281,7 @@ func (server *ApiServer) ToxicUpdate(response http.ResponseWriter, request *http
 		return
 	}
 
-	data, err := json.Marshal(toxic.GetMap())
+	data, err := json.Marshal(toxic)
 	if apiError(response, err) {
 		return
 	}

--- a/api.go
+++ b/api.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/Shopify/toxiproxy/toxics"
 	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 )
@@ -375,7 +376,7 @@ func apiError(resp http.ResponseWriter, err error) bool {
 
 func proxyWithToxics(proxy *Proxy) (result struct {
 	*Proxy
-	Toxics map[string]interface{} `json:"toxics"`
+	Toxics map[string]toxics.Toxic `json:"toxics"`
 }) {
 	result.Proxy = proxy
 	result.Toxics = proxy.Toxics.GetToxicMap()

--- a/api_test.go
+++ b/api_test.go
@@ -520,6 +520,33 @@ func TestAddToxicWithToxicity(t *testing.T) {
 	})
 }
 
+func TestAddNoop(t *testing.T) {
+	WithServer(t, func(addr string) {
+		testProxy, err := client.CreateProxy("mysql_master", "localhost:3310", "localhost:20001")
+		if err != nil {
+			t.Fatal("Unable to create proxy:", err)
+		}
+
+		noop, err := testProxy.AddToxic("foobar", "noop", "", nil)
+		if err != nil {
+			t.Fatal("Error setting toxic:", err)
+		}
+
+		if noop["toxicity"] != 1.0 || noop["name"] != "foobar" || noop["type"] != "noop" || noop["stream"] != "downstream" {
+			t.Fatal("Noop toxic did not start up with correct settings:", noop)
+		}
+
+		toxics, err := testProxy.Toxics()
+		if err != nil {
+			t.Fatal("Error returning toxics:", err)
+		}
+		toxic := AssertToxicExists(t, toxics, "foobar", "noop", "downstream", true)
+		if toxic["toxicity"] != 1.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
+	})
+}
+
 func TestUpdateToxics(t *testing.T) {
 	WithServer(t, func(addr string) {
 		testProxy, err := client.CreateProxy("mysql_master", "localhost:3310", "localhost:20001")

--- a/api_test.go
+++ b/api_test.go
@@ -389,7 +389,10 @@ func TestAddToxic(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
-		AssertToxicExists(t, toxics, "foobar", "latency", "downstream", true)
+		toxic := AssertToxicExists(t, toxics, "foobar", "latency", "downstream", true)
+		if toxic["toxicity"] != 1.0 || toxic["latency"] != 100.0 || toxic["jitter"] != 10.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
 	})
 }
 
@@ -415,7 +418,10 @@ func TestAddMultipleToxics(t *testing.T) {
 			t.Fatal("Error returning toxics:", err)
 		}
 		AssertToxicExists(t, toxics, "latency1", "latency", "downstream", true)
-		AssertToxicExists(t, toxics, "latency2", "latency", "downstream", true)
+		toxic := AssertToxicExists(t, toxics, "latency2", "latency", "downstream", true)
+		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
 		AssertToxicExists(t, toxics, "latency1", "", "upstream", false)
 		AssertToxicExists(t, toxics, "latency2", "", "upstream", false)
 	})
@@ -444,7 +450,10 @@ func TestAddConflictingToxic(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
-		AssertToxicExists(t, toxics, "foobar", "latency", "downstream", true)
+		toxic := AssertToxicExists(t, toxics, "foobar", "latency", "downstream", true)
+		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
 		AssertToxicExists(t, toxics, "foobar", "", "upstream", false)
 	})
 }
@@ -472,8 +481,42 @@ func TestAddConflictingToxicsMultistream(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
-		AssertToxicExists(t, toxics, "latency", "latency", "upstream", true)
+		toxic := AssertToxicExists(t, toxics, "latency", "latency", "upstream", true)
+		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
 		AssertToxicExists(t, toxics, "latency", "", "downstream", false)
+	})
+}
+
+func TestAddToxicWithToxicity(t *testing.T) {
+	WithServer(t, func(addr string) {
+		testProxy, err := client.CreateProxy("mysql_master", "localhost:3310", "localhost:20001")
+		if err != nil {
+			t.Fatal("Unable to create proxy:", err)
+		}
+
+		latency, err := testProxy.AddToxic("", "latency", "downstream", tclient.Toxic{
+			"latency":  100,
+			"jitter":   10,
+			"toxicity": 0.2,
+		})
+		if err != nil {
+			t.Fatal("Error setting toxic:", err)
+		}
+
+		if latency["toxicity"] != 0.2 || latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
+			t.Fatal("Latency toxic did not start up with correct settings:", latency)
+		}
+
+		toxics, err := testProxy.Toxics()
+		if err != nil {
+			t.Fatal("Error returning toxics:", err)
+		}
+		toxic := AssertToxicExists(t, toxics, "latency", "latency", "downstream", true)
+		if toxic["toxicity"] != 0.2 || toxic["latency"] != 100.0 || toxic["jitter"] != 10.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
 	})
 }
 
@@ -492,19 +535,29 @@ func TestUpdateToxics(t *testing.T) {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
+		if latency["toxicity"] != 1.0 || latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
 			t.Fatal("Latency toxic did not start up with correct settings:", latency)
 		}
 
 		latency, err = testProxy.UpdateToxic("latency", tclient.Toxic{
-			"latency": 1000,
+			"latency":  1000,
+			"toxicity": 0.5,
 		})
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["latency"] != 1000.0 || latency["jitter"] != 10.0 {
-			t.Fatal("Latency toxic did not get updated with the correct settings")
+		if latency["toxicity"] != 0.5 || latency["latency"] != 1000.0 || latency["jitter"] != 10.0 {
+			t.Fatal("Latency toxic did not get updated with the correct settings:", latency)
+		}
+
+		toxics, err := testProxy.Toxics()
+		if err != nil {
+			t.Fatal("Error returning toxics:", err)
+		}
+		toxic := AssertToxicExists(t, toxics, "latency", "latency", "downstream", true)
+		if toxic["toxicity"] != 0.5 || toxic["latency"] != 1000.0 || toxic["jitter"] != 10.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})
 }
@@ -525,7 +578,10 @@ func TestRemoveToxic(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
-		AssertToxicExists(t, toxics, "latency", "latency", "downstream", true)
+		toxic := AssertToxicExists(t, toxics, "latency", "latency", "downstream", true)
+		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+			t.Fatal("Toxic was not read back correctly:", toxic)
+		}
 
 		err = testProxy.RemoveToxic("latency")
 		if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -230,6 +230,9 @@ func (proxy *Proxy) Toxics() (Toxics, error) {
 // If a stream is not specified, it will default to downstream.
 // See https://github.com/Shopify/toxiproxy#toxics for a list of all Toxic types.
 func (proxy *Proxy) AddToxic(name, typeName, stream string, toxic Toxic) (Toxic, error) {
+	if toxic == nil {
+		toxic = make(Toxic)
+	}
 	toxic["type"] = typeName
 	if name != "" {
 		toxic["name"] = name

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -75,7 +75,7 @@ func (c *ToxicCollection) GetToxicMap() map[string]interface{} {
 	result := make(map[string]interface{})
 	for dir := range c.toxics {
 		for _, toxic := range c.toxics[dir] {
-			result[toxic.Name] = toxic.GetMap()
+			result[toxic.Name] = toxic
 		}
 	}
 	return result

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -68,11 +68,11 @@ func (c *ToxicCollection) GetToxic(name string) *toxics.ToxicWrapper {
 	return nil
 }
 
-func (c *ToxicCollection) GetToxicMap() map[string]interface{} {
+func (c *ToxicCollection) GetToxicMap() map[string]toxics.Toxic {
 	c.Lock()
 	defer c.Unlock()
 
-	result := make(map[string]interface{})
+	result := make(map[string]toxics.Toxic)
 	for dir := range c.toxics {
 		for _, toxic := range c.toxics[dir] {
 			result[toxic.Name] = toxic

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -32,14 +32,28 @@ type BufferedToxic interface {
 }
 
 type ToxicWrapper struct {
-	Toxic      `json:"-"`
-	Name       string           `json:"name"`
-	Type       string           `json:"type"`
-	Stream     string           `json:"stream"`
-	Toxicity   float32          `json:"toxicity"`
-	Direction  stream.Direction `json:"-"`
-	Index      int              `json:"-"`
-	BufferSize int              `json:"-"`
+	Toxic
+	Name       string
+	Type       string
+	Stream     string
+	Toxicity   float32
+	Direction  stream.Direction
+	Index      int
+	BufferSize int
+}
+
+// Returns a flattened map of the toxic for use with json
+func (w *ToxicWrapper) GetMap() map[string]interface{} {
+	result := make(map[string]interface{})
+	ref := reflect.ValueOf(w.Toxic).Elem()
+	for i := 0; i < ref.NumField(); i++ {
+		result[ref.Type().Field(i).Tag.Get("json")] = ref.Field(i).Interface()
+	}
+	result["name"] = w.Name
+	result["type"] = w.Type
+	result["stream"] = w.Stream
+	result["toxicity"] = w.Toxicity
+	return result
 }
 
 type ToxicStub struct {


### PR DESCRIPTION
This code is kind of a mess, but it turns out there's no way to marshal a `ToxicWrapper` into a flat object without doing this hacky reflection.
The json package will marshal it as `{"toxic":{"latency": 1000}, "name": "latency")`, which isn't what we want.

Somehow this escaped the tests before, so I've added a bunch of checks to make sure it's covered.
While I was adding checks, I also found out that toxicitiy wasn't set when updating an existing toxic.

@Sirupsen @eapache 