### PR TITLE
Added skip feature for latency. 

### DIFF
--- a/toxic_latency.go
+++ b/toxic_latency.go
@@ -43,22 +43,10 @@ func (t *LatencyToxic) delay() time.Duration {
 
 	// Do not apply this latency to this percent of packages.
 	if(skip>0){
-
-		if(skip>100) { // do not allow percentages bigger than 100
-			skip = 100
-			logrus.WithFields(logrus.Fields{
-				"skip":  skip,
-			}).Warn("Attempted to set a skip value > 100. Resetting to 100.")
-		}
-
 		var randValue = rand.Int31n(100);
 		if((randValue+1) <= skip){
 			delay = 0
 		}
-	} else if (skip <0) {
-		logrus.WithFields(logrus.Fields{
-				"skip":  skip,
-			}).Warn("Attempted to set a skip value < 0. Ignoring this value.")
 	}
 	
 	return time.Duration(delay) * time.Millisecond

--- a/toxic_latency.go
+++ b/toxic_latency.go
@@ -11,6 +11,9 @@ type LatencyToxic struct {
 	// Times in milliseconds
 	Latency int64 `json:"latency"`
 	Jitter  int64 `json:"jitter"`
+	// Percent of requests that will be passed without any effect of this latency feature.
+	// Between 0-100 . 
+	Skip int32 `json:"skip"`
 }
 
 func (t *LatencyToxic) Name() string {
@@ -29,9 +32,23 @@ func (t *LatencyToxic) delay() time.Duration {
 	// Delay = t.Latency +/- t.Jitter
 	delay := t.Latency
 	jitter := int64(t.Jitter)
+	
+	// Percent of messages that will be passed without any effect of this latency feature.
+	// When not set, skip = 0 by default, all messages are affected as usual.
+	skip := int32(t.Skip)
+	
 	if jitter > 0 {
 		delay += rand.Int63n(jitter*2) - jitter
 	}
+
+	// Do not apply this latency to this percent of packages.
+	if(skip>0){
+		var randValue = rand.Int31n(100);
+		if((randValue+1) <= skip){
+			delay = 0
+		}
+	}
+	
 	return time.Duration(delay) * time.Millisecond
 }
 

--- a/toxic_timeout.go
+++ b/toxic_timeout.go
@@ -1,6 +1,9 @@
 package main
 
-import "time"
+import (
+	"time"
+	"math/rand"
+)
 
 // The TimeoutToxic stops any data from flowing through, and will close the connection after a timeout.
 // If the timeout is set to 0, then the connection will not be closed.
@@ -8,6 +11,9 @@ type TimeoutToxic struct {
 	Enabled bool `json:"enabled"`
 	// Times in milliseconds
 	Timeout int64 `json:"timeout"`
+	// Percent of requests that will be passed without any effect of this timeout feature.
+	// Between 0-100 . 
+	Skip int32 `json:"skip"`
 }
 
 func (t *TimeoutToxic) Name() string {
@@ -23,7 +29,22 @@ func (t *TimeoutToxic) SetEnabled(enabled bool) {
 }
 
 func (t *TimeoutToxic) Pipe(stub *ToxicStub) {
+
+
 	timeout := time.Duration(t.Timeout) * time.Millisecond
+
+	// Percent of messages that will be passed without any effect of this timeout feature.
+	// When not set, skip = 0 by default, all messages are affected as usual.
+	skip := int32(t.Skip)	
+		
+	// Do not apply this timeout to this percent of packages.
+	if(skip>0){
+		var randValue = rand.Int31n(100);
+		if((randValue+1) <= skip){
+			return
+		}
+	}
+	
 	if timeout > 0 {
 		select {
 		case <-time.After(timeout):


### PR DESCRIPTION
This will let skipping the effect of latency to the specified value by skip. Currently, the latency is being applied to all messages coming to the proxy. However, sometimes we may want to skip some messages not to be effected by the latency and some messages to be effected. This skip property is introduced to let any user to skip a certain amount of messages without any latency. It is  a percentage and should be between 0 and 100. If it is not set, by default it is 0, which means as usual all the messages coming to the latency proxy will be effected by latency. If it is 40, then roughly 40% of the messages will be skipped and 60% of messages will be applied this latency.