### PR TITLE
Fix removing timeout toxic hang

### DIFF
--- a/stream/io_chan.go
+++ b/stream/io_chan.go
@@ -79,7 +79,10 @@ func (c *ChanReader) Read(out []byte) (int, error) {
 		case p := <-c.input:
 			if p == nil { // Stream was closed
 				c.buffer = nil
-				return n, io.EOF
+				if n > 0 {
+					return n, nil
+				}
+				return 0, io.EOF
 			}
 			n2 := copy(out[n:], p.Data)
 			c.buffer = p.Data[n2:]

--- a/stream/io_chan_test.go
+++ b/stream/io_chan_test.go
@@ -83,8 +83,8 @@ func TestReadLessThanWrite(t *testing.T) {
 	if n != len(send)-len(buf) {
 		t.Fatalf("Read wrong number of bytes: %d expected %d", n, len(send)-len(buf))
 	}
-	if err != io.EOF {
-		t.Fatal("Read returned wrong error after close:", err)
+	if err != nil {
+		t.Fatal("Couldn't read from stream", err)
 	}
 	if !bytes.Equal(buf[:n], send[len(buf):]) {
 		t.Fatal("Got wrong message from stream", string(buf[:n]))
@@ -110,11 +110,10 @@ func TestMultiReadWrite(t *testing.T) {
 		writer.Close()
 	}()
 	buf := make([]byte, 10)
-	read := 0
-	for i := 0; i < len(send)/10; i++ {
+	for read := 0; read < len(send); {
 		n, err := reader.Read(buf)
 		if err != nil {
-			t.Fatal("Couldn't read from stream", err)
+			t.Fatal("Couldn't read from stream", err, n)
 		}
 		if !bytes.Equal(buf[:n], send[read:read+n]) {
 			t.Fatal("Got wrong message from stream", string(buf))
@@ -123,7 +122,7 @@ func TestMultiReadWrite(t *testing.T) {
 	}
 	n, err := reader.Read(buf)
 	if err != io.EOF {
-		t.Fatal("Read returned wrong error after close:", err)
+		t.Fatal("Read returned wrong error after close:", err, string(buf[:n]))
 	}
 	if !bytes.Equal(buf[:n], send[len(send)-n:]) {
 		t.Fatal("Got wrong message from stream", string(buf[:n]))

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -92,7 +92,7 @@ func (s *ToxicStub) Run(toxic *ToxicWrapper) {
 }
 
 // Interrupt the flow of data so that the toxic controlling the stub can be replaced.
-// Returns true if the stream was successfully interrupted.
+// Returns true if the stream was successfully interrupted, or false if the stream is closed.
 func (s *ToxicStub) InterruptToxic() bool {
 	select {
 	case <-s.closed:


### PR DESCRIPTION
Fixes https://github.com/Shopify/toxiproxy/issues/88

The order toxics were interrupted caused the api to hang, since the first toxic would try to flush data to the second (which in the case of a timeout toxic will never happen).
This PR changes the operation so that the timeout is interrupted first, and then make sure the previous toxic is able to complete by manually flushing data.

@Sirupsen @sunblaze @pushrax 