### PR TITLE
Cleanup cli and add 3 new commands

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"encoding/json"
+	"log"
+	"sort"
+
 	"github.com/Shopify/toxiproxy/client"
 	"github.com/codegangsta/cli"
-	"sort"
 
 	"fmt"
 	"os"
@@ -30,78 +33,172 @@ func main() {
 			Name:    "list",
 			Aliases: []string{"l", "li", "ls"},
 			Usage:   "List all proxies",
-			Action: func(c *cli.Context) {
-				proxies, err := toxiproxyClient.Proxies()
-				if err != nil {
-					fmt.Println("Failed to retrieve proxies: ", err)
-					os.Exit(1)
-				}
-
-				var proxyNames []string
-				for proxyName := range proxies {
-					proxyNames = append(proxyNames, proxyName)
-				}
-				sort.Strings(proxyNames)
-
-				fmt.Fprintf(os.Stderr, "%sListen\t\t%sUpstream\t%sName%s\n", blueColor, yellowColor, greenColor, noColor)
-				fmt.Fprintf(os.Stderr, "%s================================================================================%s\n", grayColor, noColor)
-
-				for _, proxyName := range proxyNames {
-					proxy := proxies[proxyName]
-					fmt.Printf("%s%s\t%s%s\t%s%s%s\n", blueColor, proxy.Listen, yellowColor, proxy.Upstream, enabledColor(proxy.Enabled), proxy.Name, noColor)
-				}
-			},
+			Action:  withToxi(list, toxiproxyClient),
 		},
 		{
 			Name:    "inspect",
 			Aliases: []string{"i", "ins"},
 			Usage:   "Inspect a single proxy",
-			Action: func(c *cli.Context) {
-				proxyName := c.Args().First()
-
-				proxy, err := toxiproxyClient.Proxy(proxyName)
-				if err != nil {
-					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-					os.Exit(1)
-				}
-
-				// TODO It would be cool to include the enabled toxics in the pipe
-				// rendering --L-SC-> for latency + slow close enabled
-				fmt.Printf("%s%s%s\n", enabledColor(proxy.Enabled), proxy.Name, noColor)
-				fmt.Printf("%s%s %s---> %s%s%s\n\n", blueColor, proxy.Listen, grayColor, yellowColor, proxy.Upstream, noColor)
-
-				listToxics(proxy.ToxicsUpstream, "upstream")
-				fmt.Println()
-				listToxics(proxy.ToxicsDownstream, "downstream")
-			},
+			Action:  withToxi(inspect, toxiproxyClient),
 		},
 		{
 			Name:    "toggle",
 			Usage:   "Toggle enabled status on a proxy",
 			Aliases: []string{"tog"},
-			Action: func(c *cli.Context) {
-				proxyName := c.Args().First()
-
-				proxy, err := toxiproxyClient.Proxy(proxyName)
-				if err != nil {
-					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-					os.Exit(1)
-				}
-
-				proxy.Enabled = !proxy.Enabled
-
-				err = proxy.Save()
-				if err != nil {
-					fmt.Printf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
-					os.Exit(1)
-				}
-
-				fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
-			},
+			Action:  withToxi(toggle, toxiproxyClient),
+		},
+		{
+			Name:    "create",
+			Usage:   "Create a new proxy",
+			Aliases: []string{"c", "new"},
+			Action:  withToxi(create, toxiproxyClient),
+		},
+		{
+			Name:    "delete",
+			Usage:   "Delete a proxy",
+			Aliases: []string{"d"},
+			Action:  withToxi(delete, toxiproxyClient),
+		},
+		{
+			Name:    "add",
+			Usage:   "Add a toxic to a proxy",
+			Aliases: []string{"a"},
+			Action:  withToxi(addToxic, toxiproxyClient),
 		},
 	}
 
 	app.Run(os.Args)
+}
+
+type toxiAction func(*cli.Context, *toxiproxy.Client)
+
+func withToxi(f toxiAction, t *toxiproxy.Client) func(*cli.Context) {
+	return func(c *cli.Context) {
+		f(c, t)
+	}
+}
+
+func list(c *cli.Context, t *toxiproxy.Client) {
+	proxies, err := t.Proxies()
+	if err != nil {
+		fmt.Println("Failed to retrieve proxies: ", err)
+		os.Exit(1)
+	}
+
+	var proxyNames []string
+	for proxyName := range proxies {
+		proxyNames = append(proxyNames, proxyName)
+	}
+	sort.Strings(proxyNames)
+
+	fmt.Fprintf(os.Stderr, "%sListen\t\t%sUpstream\t%sName%s\n", blueColor, yellowColor, greenColor, noColor)
+	fmt.Fprintf(os.Stderr, "%s================================================================================%s\n", grayColor, noColor)
+
+	for _, proxyName := range proxyNames {
+		proxy := proxies[proxyName]
+		fmt.Printf("%s%s\t%s%s\t%s%s%s\n", blueColor, proxy.Listen, yellowColor, proxy.Upstream, enabledColor(proxy.Enabled), proxy.Name, noColor)
+	}
+}
+func inspect(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+
+	proxy, err := t.Proxy(proxyName)
+	if err != nil {
+		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+		os.Exit(1)
+	}
+
+	// TODO It would be cool to include the enabled toxics in the pipe
+	// rendering --L-SC-> for latency + slow close enabled
+	fmt.Printf("%s%s%s\n", enabledColor(proxy.Enabled), proxy.Name, noColor)
+	fmt.Printf("%s%s %s---> %s%s%s\n\n", blueColor, proxy.Listen, grayColor, yellowColor, proxy.Upstream, noColor)
+
+	listToxics(proxy.ToxicsUpstream, "upstream")
+	fmt.Println()
+	listToxics(proxy.ToxicsDownstream, "downstream")
+}
+
+func toggle(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+
+	proxy, err := t.Proxy(proxyName)
+	if err != nil {
+		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+		os.Exit(1)
+	}
+
+	proxy.Enabled = !proxy.Enabled
+
+	err = proxy.Save()
+	if err != nil {
+		fmt.Printf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
+}
+
+func create(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().Get(0)
+	listen := c.Args().Get(1)
+	upstream := c.Args().Get(2)
+	p := &toxiproxy.Proxy{
+		Name:     proxyName,
+		Listen:   listen,
+		Upstream: upstream,
+		Enabled:  true,
+	}
+	p = t.NewProxy(p)
+	err := p.Create()
+	if err != nil {
+		log.Fatalf("Failed to create proxy: %s\n",
+			err.Error())
+	}
+	fmt.Printf("Created new proxy %s\n", proxyName)
+}
+
+func delete(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	p, err := t.Proxy(proxyName)
+	if err != nil {
+		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+		os.Exit(1)
+	}
+
+	err = p.Delete()
+	if err != nil {
+		log.Fatalf("Failed to delete proxy: %s\n",
+			err.Error())
+	}
+	fmt.Printf("Deleted proxy %s\n", proxyName)
+}
+
+func addToxic(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().Get(0)
+	toxicName := c.Args().Get(1)
+	direction := c.Args().Get(2)
+	toxicConfig := c.Args().Get(3)
+	p, err := t.Proxy(proxyName)
+	if err != nil {
+		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+		os.Exit(1)
+	}
+	conf := parseToxicConfig(toxicConfig)
+	_, err = p.SetToxic(toxicName, direction, conf)
+	if err != nil {
+		log.Fatalf("Failed to set toxic: %s\n", err.Error())
+	}
+	fmt.Printf("Set %s %s toxic on proxy %s\n", direction,
+		toxicName, proxyName)
+}
+
+func parseToxicConfig(raw string) map[string]interface{} {
+	parsed := map[string]interface{}{}
+	err := json.Unmarshal([]byte(raw), &parsed)
+	if err != nil {
+		log.Fatal("Toxic config parsing error: %s\n", err)
+	}
+	return parsed
 }
 
 func enabledColor(enabled bool) string {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -106,10 +106,10 @@ func main() {
 
 func enabledColor(enabled bool) string {
 	if enabled {
-		return "\x1b[32m"
+		return greenColor
 	}
 
-	return "\x1b[31m"
+	return redColor
 }
 
 func enabledText(enabled bool) string {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -131,8 +131,7 @@ func withToxi(f toxiAction, t *toxiproxy.Client) func(*cli.Context) {
 func list(c *cli.Context, t *toxiproxy.Client) {
 	proxies, err := t.Proxies()
 	if err != nil {
-		fmt.Println("Failed to retrieve proxies: ", err)
-		os.Exit(1)
+		log.Fatalln("Failed to retrieve proxies: ", err)
 	}
 
 	var proxyNames []string
@@ -154,8 +153,7 @@ func inspect(c *cli.Context, t *toxiproxy.Client) {
 
 	proxy, err := t.Proxy(proxyName)
 	if err != nil {
-		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-		os.Exit(1)
+		log.Fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
 	}
 
 	// TODO It would be cool to include the enabled toxics in the pipe
@@ -173,16 +171,14 @@ func toggle(c *cli.Context, t *toxiproxy.Client) {
 
 	proxy, err := t.Proxy(proxyName)
 	if err != nil {
-		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-		os.Exit(1)
+		log.Fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
 	}
 
 	proxy.Enabled = !proxy.Enabled
 
 	err = proxy.Save()
 	if err != nil {
-		fmt.Printf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
-		os.Exit(1)
+		log.Fatalf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
 	}
 
 	fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
@@ -201,8 +197,7 @@ func create(c *cli.Context, t *toxiproxy.Client) {
 	p = t.NewProxy(p)
 	err := p.Create()
 	if err != nil {
-		log.Fatalf("Failed to create proxy: %s\n",
-			err.Error())
+		log.Fatalf("Failed to create proxy: %s\n", err.Error())
 	}
 	fmt.Printf("Created new proxy %s\n", proxyName)
 }
@@ -211,14 +206,12 @@ func delete(c *cli.Context, t *toxiproxy.Client) {
 	proxyName := c.String("name")
 	p, err := t.Proxy(proxyName)
 	if err != nil {
-		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-		os.Exit(1)
+		log.Fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
 	}
 
 	err = p.Delete()
 	if err != nil {
-		log.Fatalf("Failed to delete proxy: %s\n",
-			err.Error())
+		log.Fatalf("Failed to delete proxy: %s\n", err.Error())
 	}
 	fmt.Printf("Deleted proxy %s\n", proxyName)
 }
@@ -230,16 +223,14 @@ func addToxic(c *cli.Context, t *toxiproxy.Client) {
 	toxicConfig := c.String("fields")
 	p, err := t.Proxy(proxyName)
 	if err != nil {
-		fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-		os.Exit(1)
+		log.Fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
 	}
 	conf := parseToxicConfig(toxicConfig)
 	_, err = p.SetToxic(toxicName, direction, conf)
 	if err != nil {
 		log.Fatalf("Failed to set toxic: %s\n", err.Error())
 	}
-	fmt.Printf("Set %s %s toxic on proxy %s\n", direction,
-		toxicName, proxyName)
+	fmt.Printf("Set %s %s toxic on proxy %s\n", direction, toxicName, proxyName)
 }
 
 func parseToxicConfig(raw string) map[string]interface{} {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -19,6 +19,7 @@ const (
 )
 
 func main() {
+	defer fmt.Print(noColor) // make sure to clear unwanted colors
 	toxiproxyClient := toxiproxy.NewClient("http://localhost:8474")
 
 	app := cli.NewApp()

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -258,8 +258,8 @@ func enabledText(enabled bool) string {
 	return "disabled"
 }
 
-// TODO should have upstream and downstream headings
 func listToxics(toxics toxiproxy.Toxics, direction string) {
+	fmt.Printf("%s%s\n", noColor, direction)
 	for name, toxic := range toxics {
 		fmt.Printf("%s%s direction=%s", enabledColor(toxic["enabled"].(bool)), name, direction)
 


### PR DESCRIPTION
I thought I'd work on this.
**changes:**
1. Hard coded color constants were replaced with variables.
2. A `defer fmt.Printf(noColor)` was added to the beginning of `main` to return to default terminal colors on program exit.
3. Inlined command functions were [factored out](https://github.com/jpittis/toxiproxy/blob/46bb9443ac9fbbd8953c9a37986486a3cd9572c1/cli/cli.go#L32-L49) into the toplevel.
4. Create proxy, delete proxy and add toxic commands were added.

`create, c, new	Create a new proxy`
````
$ ./cli create myProxy 127.0.0.1:4444 127.0.0.1:7777
Created new proxy myProxy
````

`add, a		Add a toxic to a proxy`
````
$ ./cli add myProxy latency downstream '{"enabled":true,"latency":50,"jitter":30}'
Set downstream latency toxic on proxy myProxy
````

`delete, d		Delete a proxy`
````
$ ./cli delete myProxy
Deleted proxy myProxy
````

**I few things I havn't done yet that I think need doing:**
1. We need better command discriptions and examples.
2. Removing toxics wasn't implemented beccause the go client doesn't implement very good toxic manipulation. That can be easily fixed too.
@Sirupsen, @xthexder: Is this in the right direction?