### PR TITLE
api: toxics are sent to client as array rather than map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Make `ChanReader` in the `stream` package interruptible #77
 * Define proxy buffer sizes per-toxic (Fixes #72)
 * Fix slicer toxic testing race condition #71
+* API and client return toxics as array rather than a map of name to toxic #92
 
 # 1.2.1
 

--- a/api.go
+++ b/api.go
@@ -205,7 +205,7 @@ func (server *ApiServer) ToxicIndex(response http.ResponseWriter, request *http.
 		return
 	}
 
-	toxics := proxy.Toxics.GetToxicMap()
+	toxics := proxy.Toxics.GetToxicArray()
 	data, err := json.Marshal(toxics)
 	if apiError(response, err) {
 		return
@@ -376,9 +376,9 @@ func apiError(resp http.ResponseWriter, err error) bool {
 
 func proxyWithToxics(proxy *Proxy) (result struct {
 	*Proxy
-	Toxics map[string]toxics.Toxic `json:"toxics"`
+	Toxics []toxics.Toxic `json:"toxics"`
 }) {
 	result.Proxy = proxy
-	result.Toxics = proxy.Toxics.GetToxicMap()
+	result.Toxics = proxy.Toxics.GetToxicArray()
 	return
 }

--- a/api_test.go
+++ b/api_test.go
@@ -655,8 +655,21 @@ func TestInvalidStream(t *testing.T) {
 	})
 }
 
+func findToxic(t *testing.T, name string, toxics tclient.Toxics) (tclient.Toxic, bool) {
+	for _, tox := range toxics {
+		n, ok := tox["name"]
+		if !ok {
+			t.Fatal("expected toxic to have name field")
+		}
+		if name == n {
+			return tox, true
+		}
+	}
+	return nil, false
+}
+
 func AssertToxicExists(t *testing.T, toxics tclient.Toxics, name, typeName, stream string, exists bool) tclient.Toxic {
-	toxic, found := toxics[name]
+	toxic, found := findToxic(t, name, toxics)
 	var actualType, actualStream string
 	if found {
 		actualType = toxic["type"].(string)

--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,7 @@ type Client struct {
 }
 
 type Toxic map[string]interface{}
-type Toxics map[string]Toxic
+type Toxics []Toxic
 
 // Proxy represents a Proxy.
 type Proxy struct {
@@ -216,7 +216,7 @@ func (proxy *Proxy) Toxics() (Toxics, error) {
 		return nil, err
 	}
 
-	toxics := make(Toxics)
+	toxics := make(Toxics, 0)
 	err = json.NewDecoder(resp.Body).Decode(&toxics)
 	if err != nil {
 		return nil, err

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -68,14 +68,14 @@ func (c *ToxicCollection) GetToxic(name string) *toxics.ToxicWrapper {
 	return nil
 }
 
-func (c *ToxicCollection) GetToxicMap() map[string]toxics.Toxic {
+func (c *ToxicCollection) GetToxicArray() []toxics.Toxic {
 	c.Lock()
 	defer c.Unlock()
 
-	result := make(map[string]toxics.Toxic)
+	result := make([]toxics.Toxic, 0)
 	for dir := range c.toxics {
 		for _, toxic := range c.toxics[dir] {
-			result[toxic.Name] = toxic
+			result = append(result, toxic)
 		}
 	}
 	return result


### PR DESCRIPTION
> Would it be simpler to return an array of toxics instead of a map with the names as keys?

This changes the api to return a list of toxics rather than a map of name to toxic.

I did not change how toxics are implemented internally. Instead, this is a front end change.

@Sirupsen and @xthexder were unsure about whether this is needed.

## Before
```
"toxics": {
    "myToxic1": {"name": "myToxic1"...},
    "myToxic2": {"name": "myToxic2"...}
}
```
## After
```
"toxics": [
    {"name": "myToxic1"...},
    {"name": "myToxic2"...}
]
```
