### PR TITLE
Cli 2.0 dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 toxiproxy
 toxiproxy-server
+cli
 toxiproxy.test
 testing
 testing.test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Add `Dockerfile`
 * Fix latency toxic limiting bandwidth #67
 * Add Slicer toxic
+* Add CLI
 
 # 1.1.0
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ tmp/build/toxiproxy-client-windows-amd64.exe:
 $(DEB): tmp/build/toxiproxy-server-linux-amd64 tmp/build/toxiproxy-client-linux-amd64
 	fpm -t deb \
 		-s dir \
+		-p tmp/build/ \
 		--name "toxiproxy" \
 		--version $(VERSION) \
 		--license MIT \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NAME=toxiproxy-server
+NAME=toxiproxy
 VERSION=$(shell cat VERSION)
 DEB=pkg/$(NAME)_$(VERSION)_amd64.deb
 GODEP_PATH=$(shell pwd)/Godeps/_workspace
@@ -12,35 +12,40 @@ build:
 
 all: deb linux darwin windows
 deb: $(DEB)
-darwin: tmp/build/$(NAME)-darwin-amd64
-linux: tmp/build/$(NAME)-linux-amd64
-windows: tmp/build/$(NAME)-windows-amd64.exe
+
+darwin: tmp/build/toxiproxy-server-darwin-amd64 tmp/build/toxiproxy-client-darwin-amd64
+linux: tmp/build/toxiproxy-server-linux-amd64 tmp/build/toxiproxy-client-linux-amd64
+windows: tmp/build/toxiproxy-server-windows-amd64.exe tmp/build/toxiproxy-client-windows-amd64.exe
+
 release: all docker
 
 clean:
 	rm -f tmp/build/*
-	rm -f $(NAME)
+	#rm -f $(NAME)
 	rm -f *.deb
 
 test:
 	GOMAXPROCS=4 GOPATH=$(COMBINED_GOPATH) go test -v -race ./...
 
-tmp/build/toxiproxy-linux-amd64:
+tmp/build/toxiproxy-server-linux-amd64:
 	GOOS=linux GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(VERSION)" -o $(@) ./cmd
 
-tmp/build/toxiproxy-darwin-amd64:
+tmp/build/toxiproxy-server-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(VERSION)" -o $(@) ./cmd
 
-tmp/build/toxiproxy-windows-amd64.exe:
+tmp/build/toxiproxy-server-windows-amd64.exe:
 	GOOS=windows GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(VERSION)" -o $(@) ./cmd
 
-docker:
-	docker build --tag="shopify/toxiproxy:$(VERSION)" .
-	docker tag -f shopify/toxiproxy:$(VERSION) shopify/toxiproxy:latest
-	docker push shopify/toxiproxy:$(VERSION)
-	docker push shopify/toxiproxy:latest
+tmp/build/toxiproxy-client-linux-amd64:
+	GOOS=linux GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(VERSION)" -o $(@) ./cli
 
-$(DEB): tmp/build/toxiproxy-linux-amd64
+tmp/build/toxiproxy-client-darwin-amd64:
+	GOOS=darwin GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(VERSION)" -o $(@) ./cli
+
+tmp/build/toxiproxy-client-windows-amd64.exe:
+	GOOS=windows GOARCH=amd64 GOPATH=$(COMBINED_GOPATH) go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(VERSION)" -o $(@) ./cli
+
+$(DEB): tmp/build/toxiproxy-server-linux-amd64 tmp/build/toxiproxy-client-linux-amd64
 	fpm -t deb \
 		-s dir \
 		--name "toxiproxy" \
@@ -52,5 +57,13 @@ $(DEB): tmp/build/toxiproxy-linux-amd64
 		--maintainer "Simon Eskildsen <simon.eskildsen@shopify.com>" \
 		--description "TCP proxy to simulate network and system conditions" \
 		--url "https://github.com/Shopify/toxiproxy" \
-		$<=/usr/bin/$(NAME) \
+		$(word 1,$^)=/usr/bin/toxiproxy \
+		$(word 1,$^)=/usr/bin/toxiproxy-server \
+		$(word 2,$^)=/usr/bin/toxiproxy-client \
 		./share/toxiproxy.conf=/etc/init/toxiproxy.conf
+
+docker:
+	docker build --tag="shopify/toxiproxy:$(VERSION)" .
+	docker tag -f shopify/toxiproxy:$(VERSION) shopify/toxiproxy:latest
+	docker push shopify/toxiproxy:$(VERSION)
+	docker push shopify/toxiproxy:latest

--- a/api_test.go
+++ b/api_test.go
@@ -586,7 +586,7 @@ func TestUpdateToxics(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		latency, err := testProxy.AddToxic("", "latency", "downstream", 1, tclient.Attributes{
+		latency, err := testProxy.AddToxic("", "latency", "downstream", -1, tclient.Attributes{
 			"latency": 100,
 			"jitter":  10,
 		})
@@ -609,13 +609,24 @@ func TestUpdateToxics(t *testing.T) {
 			t.Fatal("Latency toxic did not get updated with the correct settings:", latency)
 		}
 
+		latency, err = testProxy.UpdateToxic("latency_downstream", -1, tclient.Attributes{
+			"latency": 500,
+		})
+		if err != nil {
+			t.Fatal("Error setting toxic:", err)
+		}
+
+		if latency.Toxicity != 0.5 || latency.Attributes["latency"] != 500.0 || latency.Attributes["jitter"] != 10.0 {
+			t.Fatal("Latency toxic did not get updated with the correct settings:", latency)
+		}
+
 		toxics, err := testProxy.Toxics()
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
 
 		toxic := AssertToxicExists(t, toxics, "latency_downstream", "latency", "downstream", true)
-		if toxic.Toxicity != 0.5 || toxic.Attributes["latency"] != 1000.0 || toxic.Attributes["jitter"] != 10.0 {
+		if toxic.Toxicity != 0.5 || toxic.Attributes["latency"] != 500.0 || toxic.Attributes["jitter"] != 10.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/Shopify/toxiproxy/client"
 	"github.com/codegangsta/cli"
-	"sort"
 
 	"fmt"
 	"os"
@@ -14,88 +17,165 @@ const (
 	greenColor  = "\x1b[32m"
 	yellowColor = "\x1b[33m"
 	blueColor   = "\x1b[34m"
+	cyanColor   = "\x1b[36m"
+	purpleColor = "\x1b[35m"
 	grayColor   = "\x1b[37m"
 	noColor     = "\x1b[0m"
 )
+
+var toxicDescription = `
+	Default Toxics:
+	latency:	delay all data +/- jitter
+		latency=<ms>,jitter=<ms>
+
+	bandwidth:	limit to max kb/s
+		rate=<KB/s>
+
+	slow_close:	delay from closing
+		delay=<ms>
+
+	timeout: 	stop all data and close after timeout
+	         	timeout=<ms>
+
+	slicer: 	slice data into bits with optional delay
+	        	average_size=<byes>,size_variation=<bytes>,delay=<microseconds>
+
+	toxic add:
+		usage: toxiproxy-client add <proxyName> --type <toxicType> --toxicName <toxicName> \
+		--attributes <key1=value1,key2=value2...> --upstream --downstream
+
+		example: toxiproxy-client toxic add myProxy -t latency -n myToxic -f latency=100,jitter=50
+
+	toxic update:
+		usage: toxiproxy-client update <proxyName> --toxicName <toxicName> \
+		--attributes <key1=value1,key2=value2...>
+		
+		example: toxiproxy-client toxic update myProxy -n myToxic -f jitter=25
+	
+	toxic delete:
+		usage: toxiproxy-client update <proxyName> --toxicName <toxicName>
+
+		example: toxiproxy-client toxic delete myProxy -n myToxic
+`
 
 func main() {
 	toxiproxyClient := toxiproxy.NewClient("http://localhost:8474")
 
 	app := cli.NewApp()
 	app.Name = "Toxiproxy"
+	app.Version = "2.0-alpha" // We're still improving the client ui.
 	app.Usage = "Simulate network and system conditions"
 	app.Commands = []cli.Command{
 		{
 			Name:    "list",
+			Usage:   "list all proxies\n\tusage: 'toxiproxy-client list'\n",
 			Aliases: []string{"l", "li", "ls"},
-			Usage:   "List all proxies",
-			Action: func(c *cli.Context) {
-				proxies, err := toxiproxyClient.Proxies()
-				if err != nil {
-					fmt.Println("Failed to retrieve proxies: ", err)
-					os.Exit(1)
-				}
-
-				var proxyNames []string
-				for proxyName := range proxies {
-					proxyNames = append(proxyNames, proxyName)
-				}
-				sort.Strings(proxyNames)
-
-				fmt.Fprintf(os.Stderr, "%sListen\t\t%sUpstream\t%sName%s\n", blueColor, yellowColor, greenColor, noColor)
-				fmt.Fprintf(os.Stderr, "%s================================================================================%s\n", grayColor, noColor)
-
-				for _, proxyName := range proxyNames {
-					proxy := proxies[proxyName]
-					fmt.Printf("%s%s\t%s%s\t%s%s%s\n", blueColor, proxy.Listen, yellowColor, proxy.Upstream, enabledColor(proxy.Enabled), proxy.Name, noColor)
-				}
-			},
+			Action:  withToxi(list, toxiproxyClient),
 		},
 		{
 			Name:    "inspect",
 			Aliases: []string{"i", "ins"},
-			Usage:   "Inspect a single proxy",
-			Action: func(c *cli.Context) {
-				proxyName := c.Args().First()
-
-				proxy, err := toxiproxyClient.Proxy(proxyName)
-				if err != nil {
-					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-					os.Exit(1)
-				}
-
-				// TODO It would be cool to include the enabled toxics in the pipe
-				// rendering --L-SC-> for latency + slow close enabled
-				fmt.Printf("%s%s%s\n", enabledColor(proxy.Enabled), proxy.Name, noColor)
-				fmt.Printf("%s%s %s---> %s%s%s\n\n", blueColor, proxy.Listen, grayColor, yellowColor, proxy.Upstream, noColor)
-
-				listToxics(proxy.ToxicsUpstream, "upstream")
-				fmt.Println()
-				listToxics(proxy.ToxicsDownstream, "downstream")
-			},
+			Usage:   "inspect a single proxy\n\tusage: 'toxiproxy-client inspect <proxyName>'\n",
+			Action:  withToxi(inspect, toxiproxyClient),
 		},
 		{
 			Name:    "toggle",
-			Usage:   "Toggle enabled status on a proxy",
+			Usage:   "\ttoggle enabled status on a proxy\n\t\tusage: 'toxiproxy-client toggle <proxyName>'\n",
 			Aliases: []string{"tog"},
-			Action: func(c *cli.Context) {
-				proxyName := c.Args().First()
-
-				proxy, err := toxiproxyClient.Proxy(proxyName)
-				if err != nil {
-					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
-					os.Exit(1)
-				}
-
-				proxy.Enabled = !proxy.Enabled
-
-				err = proxy.Save()
-				if err != nil {
-					fmt.Printf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
-					os.Exit(1)
-				}
-
-				fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
+			Action:  withToxi(toggle, toxiproxyClient),
+		},
+		{
+			Name:    "create",
+			Usage:   "create a new proxy\n\tusage: 'toxiproxy-client create <proxyName> --listen <addr> --upstream <addr>'\n",
+			Aliases: []string{"c", "new"},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "listen, l",
+					Usage: "proxy will listen on this address",
+				},
+				cli.StringFlag{
+					Name:  "upstream, u",
+					Usage: "proxy will forward to this address",
+				},
+			},
+			Action: withToxi(create, toxiproxyClient),
+		},
+		{
+			Name:    "delete",
+			Usage:   "\tdelete a proxy\n\t\tusage: 'toxiproxy-client delete <proxyName>'\n",
+			Aliases: []string{"d"},
+			Action:  withToxi(delete, toxiproxyClient),
+		},
+		{
+			Name:        "toxic",
+			Aliases:     []string{"t"},
+			Usage:       "\tadd, remove or update a toxic\n\t\tusage: see 'toxiproxy-client toxic'\n",
+			Description: toxicDescription,
+			Subcommands: []cli.Command{
+				{
+					Name:    "add",
+					Aliases: []string{"a"},
+					Usage:   "add a new toxic",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "toxicName, n",
+							Usage: "name of the toxic",
+						},
+						cli.StringFlag{
+							Name:  "type, t",
+							Usage: "type of toxic",
+						},
+						cli.StringFlag{
+							Name:  "toxicity, tox",
+							Usage: "toxicity of toxic",
+						},
+						cli.StringFlag{
+							Name:  "attributes, a",
+							Usage: "comma seperated key=value toxic attributes",
+						},
+						cli.BoolFlag{
+							Name:  "upstream, u",
+							Usage: "add toxic to upstream",
+						},
+						cli.BoolFlag{
+							Name:  "downstream, d",
+							Usage: "add toxic to downstream",
+						},
+					},
+					Action: withToxi(addToxic, toxiproxyClient),
+				},
+				{
+					Name:    "update",
+					Aliases: []string{"u"},
+					Usage:   "update an enabled toxic",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "toxicName, n",
+							Usage: "name of the toxic",
+						},
+						cli.StringFlag{
+							Name:  "toxicity, tox",
+							Usage: "toxicity of toxic",
+						},
+						cli.StringFlag{
+							Name:  "attributes, a",
+							Usage: "comma seperated key=value toxic attributes",
+						},
+					},
+					Action: withToxi(updateToxic, toxiproxyClient),
+				},
+				{
+					Name:    "remove",
+					Aliases: []string{"r", "delete", "d"},
+					Usage:   "remove an enabled toxic",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "toxicName, n",
+							Usage: "name of the toxic",
+						},
+					},
+					Action: withToxi(removeToxic, toxiproxyClient),
+				},
 			},
 		},
 	}
@@ -103,12 +183,269 @@ func main() {
 	app.Run(os.Args)
 }
 
-func enabledColor(enabled bool) string {
-	if enabled {
-		return "\x1b[32m"
+type toxiAction func(*cli.Context, *toxiproxy.Client)
+
+func withToxi(f toxiAction, t *toxiproxy.Client) func(*cli.Context) {
+	return func(c *cli.Context) {
+		f(c, t)
+	}
+}
+
+func list(c *cli.Context, t *toxiproxy.Client) {
+	proxies, err := t.Proxies()
+	if err != nil {
+		fatalf("Failed to retrieve proxies: %s", err)
 	}
 
-	return "\x1b[31m"
+	var proxyNames []string
+	for proxyName := range proxies {
+		proxyNames = append(proxyNames, proxyName)
+	}
+	sort.Strings(proxyNames)
+
+	fmt.Fprintf(os.Stderr, "%sListen\t\t%sUpstream\t%sName\t%sEnabled\t%sToxics\n%s", blueColor, yellowColor,
+		greenColor, purpleColor, redColor, noColor)
+	fmt.Fprintf(os.Stderr, "%s======================================================================\n", noColor)
+
+	if len(proxyNames) == 0 {
+		fmt.Printf("%sno proxies\n\n%s", redColor, noColor)
+		hint("create a proxy with `toxiproxy-client create`")
+		return
+	}
+
+	for _, proxyName := range proxyNames {
+		proxy := proxies[proxyName]
+		numToxics := strconv.Itoa(len(proxy.ActiveToxics))
+		if numToxics == "0" {
+			numToxics = "None"
+		}
+		fmt.Printf("%s%s\t%s%s\t%s%s\t%s%v\t%s%s%s\n", blueColor, proxy.Listen, yellowColor, proxy.Upstream,
+			enabledColor(proxy.Enabled), proxy.Name, purpleColor, proxy.Enabled, redColor, numToxics, noColor)
+	}
+	fmt.Println()
+	hint("inspect a toxic with `toxiproxy-client inspect <proxyName>`")
+}
+func inspect(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+
+	proxy, err := t.Proxy(proxyName)
+	if err != nil {
+		fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	fmt.Printf("%sName: %s%s\t", purpleColor, noColor, proxy.Name)
+	fmt.Printf("%sListen: %s%s\t", blueColor, noColor, proxy.Listen)
+	fmt.Printf("%sUpstream: %s%s\n", yellowColor, noColor, proxy.Upstream)
+	fmt.Printf("%s======================================================================\n", noColor)
+
+	splitToxics := func(toxics toxiproxy.Toxics) (toxiproxy.Toxics, toxiproxy.Toxics) {
+		upstream := make(toxiproxy.Toxics, 0)
+		downstream := make(toxiproxy.Toxics, 0)
+		for _, toxic := range toxics {
+			if toxic.Stream == "upstream" {
+				upstream = append(upstream, toxic)
+			} else {
+				downstream = append(downstream, toxic)
+			}
+		}
+		return upstream, downstream
+	}
+
+	if len(proxy.ActiveToxics) == 0 {
+		fmt.Printf("%sProxy has no toxics enabled.\n%s", redColor, noColor)
+	} else {
+		up, down := splitToxics(proxy.ActiveToxics)
+		listToxics(up, "Upstream")
+		fmt.Println()
+		listToxics(down, "Downstream")
+	}
+	fmt.Println()
+
+	hint("add a toxic with `toxiproxy-client toxic add`")
+}
+
+func toggle(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+
+	proxy, err := t.Proxy(proxyName)
+	if err != nil {
+		fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	proxy.Enabled = !proxy.Enabled
+
+	err = proxy.Save()
+	if err != nil {
+		fatalf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
+}
+
+func create(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+	listen := getArgOrFail(c, "listen")
+	upstream := getArgOrFail(c, "upstream")
+	_, err := t.CreateProxy(proxyName, listen, upstream)
+	if err != nil {
+		fatalf("Failed to create proxy: %s\n", err.Error())
+	}
+	fmt.Printf("Created new proxy %s\n", proxyName)
+}
+
+func delete(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+	p, err := t.Proxy(proxyName)
+	if err != nil {
+		fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	err = p.Delete()
+	if err != nil {
+		fatalf("Failed to delete proxy: %s\n", err.Error())
+	}
+	fmt.Printf("Deleted proxy %s\n", proxyName)
+}
+
+func parseToxicity(c *cli.Context, defaultToxicity float32) float32 {
+	var toxicity = defaultToxicity
+	toxicityString := c.String("toxicity")
+	if toxicityString != "" {
+		tox, err := strconv.ParseFloat(toxicityString, 32)
+		if err != nil || tox > 1 || tox < 0 {
+			fatalf("toxicity should be a float between 0 and 1.\n")
+		}
+		toxicity = float32(tox)
+	}
+	return toxicity
+}
+
+func addToxic(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+	toxicName := c.String("toxicName")
+	toxicType := getArgOrFail(c, "type")
+	toxicAttributes := getArgOrFail(c, "attributes")
+
+	upstream := c.Bool("upstream")
+	downstream := c.Bool("downstream")
+
+	toxicity := parseToxicity(c, 1.0)
+
+	attributes := parseAttributes(toxicAttributes)
+
+	p, err := t.Proxy(proxyName)
+	if err != nil {
+		fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	addToxic := func(stream string) {
+		t, err := p.AddToxic(toxicName, toxicType, stream, toxicity, attributes)
+		if err != nil {
+			fatalf("Failed to add toxic: %s\n", err.Error())
+		}
+		toxicName = t.Name
+		fmt.Printf("Added %s %s toxic '%s' on proxy '%s'\n", stream, toxicType, toxicName, proxyName)
+	}
+
+	if upstream {
+		addToxic("upstream")
+	}
+	// Default to downstream.
+	if downstream || (!downstream && !upstream) {
+		addToxic("downstream")
+	}
+}
+
+func updateToxic(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+	toxicName := getArgOrFail(c, "toxicName")
+	toxicAttributes := getArgOrFail(c, "attributes")
+
+	attributes := parseAttributes(toxicAttributes)
+
+	p, err := t.Proxy(proxyName)
+	if err != nil {
+		fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	toxicity := parseToxicity(c, -1)
+
+	_, err = p.UpdateToxic(toxicName, toxicity, attributes)
+	if err != nil {
+		fatalf("Failed to update toxic: %s\n", err.Error())
+	}
+
+	fmt.Printf("Updated toxic '%s' on proxy '%s'\n", toxicName, proxyName)
+}
+
+func removeToxic(c *cli.Context, t *toxiproxy.Client) {
+	proxyName := c.Args().First()
+	if proxyName == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Proxy name is required as the first argument.\n")
+	}
+	toxicName := getArgOrFail(c, "toxicName")
+
+	p, err := t.Proxy(proxyName)
+	if err != nil {
+		fatalf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+	}
+
+	err = p.RemoveToxic(toxicName)
+	if err != nil {
+		fatalf("Failed to remove toxic: %s\n", err.Error())
+	}
+
+	fmt.Printf("Removed toxic '%s' on proxy '%s'\n", toxicName, proxyName)
+}
+
+func parseAttributes(raw string) toxiproxy.Attributes {
+	parsed := map[string]interface{}{}
+	keyValues := strings.Split(raw, ",")
+	for _, keyValue := range keyValues {
+		kv := strings.SplitN(keyValue, "=", 2)
+		if len(kv) != 2 {
+			fatalf("Attributes should be in format key1=value1,key2=value2\n")
+		}
+		value, err := strconv.Atoi(kv[1])
+		if err != nil {
+			fatalf("Toxic attributes was expected to be an integer.\n")
+		}
+		parsed[kv[0]] = value
+	}
+	return parsed
+}
+
+func enabledColor(enabled bool) string {
+	if enabled {
+		return greenColor
+	}
+
+	return redColor
 }
 
 func enabledText(enabled bool) string {
@@ -119,14 +456,61 @@ func enabledText(enabled bool) string {
 	return "disabled"
 }
 
-func listToxics(toxics toxiproxy.Toxics, direction string) {
-	for name, toxic := range toxics {
-		fmt.Printf("%s%s direction=%s", enabledColor(toxic["enabled"].(bool)), name, direction)
+type attribute struct {
+	key   string
+	value interface{}
+}
 
-		for property, value := range toxic {
-			fmt.Printf(" %s=", property)
-			fmt.Print(value)
-		}
-		fmt.Println()
+type attributeList []attribute
+
+func (a attributeList) Len() int           { return len(a) }
+func (a attributeList) Less(i, j int) bool { return a[i].key < a[j].key }
+func (a attributeList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func sortedAttributes(attrs toxiproxy.Attributes) attributeList {
+	li := make(attributeList, 0, len(attrs))
+	for k, v := range attrs {
+		li = append(li, attribute{k, v.(float64)})
 	}
+	sort.Sort(li)
+	return li
+}
+
+func listToxics(toxics toxiproxy.Toxics, stream string) {
+	fmt.Printf("%s%s toxics:\n%s", greenColor, stream, noColor)
+	if len(toxics) == 0 {
+		fmt.Printf("%sProxy has no %s toxics enabled.\n%s", redColor, stream, noColor)
+		return
+	}
+	for _, t := range toxics {
+		fmt.Printf("%s%s:%s ", redColor, t.Name, noColor)
+		fmt.Printf("type=%s ", t.Type)
+		fmt.Printf("stream=%s ", t.Stream)
+		fmt.Printf("toxicity=%.2f ", t.Toxicity)
+		fmt.Printf("attributes=[")
+		sorted := sortedAttributes(t.Attributes)
+		for _, a := range sorted {
+			fmt.Printf(" %s=", a.key)
+			fmt.Print(a.value)
+		}
+		fmt.Printf(" ]\n")
+	}
+}
+
+func getArgOrFail(c *cli.Context, name string) string {
+	arg := c.String(name)
+	if arg == "" {
+		cli.ShowSubcommandHelp(c)
+		fatalf("Required argument '%s' was empty.\n", name)
+	}
+	return arg
+}
+
+func hint(m string) {
+	fmt.Printf("%sHint: %s\n", noColor, m)
+}
+
+func fatalf(m string, args ...interface{}) {
+	fmt.Printf(m, args...)
+	os.Exit(1)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"github.com/Shopify/toxiproxy/client"
+	"github.com/codegangsta/cli"
+	"sort"
+
+	"fmt"
+	"os"
+)
+
+const (
+	redColor    = "\x1b[31m"
+	greenColor  = "\x1b[32m"
+	yellowColor = "\x1b[33m"
+	blueColor   = "\x1b[34m"
+	grayColor   = "\x1b[37m"
+	noColor     = "\x1b[0m"
+)
+
+func main() {
+	toxiproxyClient := toxiproxy.NewClient("http://localhost:8474")
+
+	app := cli.NewApp()
+	app.Name = "Toxiproxy"
+	app.Usage = "Simulate network and system conditions"
+	app.Commands = []cli.Command{
+		{
+			Name:    "list",
+			Aliases: []string{"l", "li", "ls"},
+			Usage:   "List all proxies",
+			Action: func(c *cli.Context) {
+				proxies, err := toxiproxyClient.Proxies()
+				if err != nil {
+					fmt.Println("Failed to retrieve proxies: ", err)
+					os.Exit(1)
+				}
+
+				var proxyNames []string
+				for proxyName := range proxies {
+					proxyNames = append(proxyNames, proxyName)
+				}
+				sort.Strings(proxyNames)
+
+				fmt.Fprintf(os.Stderr, "%sListen\t\t%sUpstream\t%sName%s\n", blueColor, yellowColor, greenColor, noColor)
+				fmt.Fprintf(os.Stderr, "%s================================================================================%s\n", grayColor, noColor)
+
+				for _, proxyName := range proxyNames {
+					proxy := proxies[proxyName]
+					fmt.Printf("%s%s\t%s%s\t%s%s%s\n", blueColor, proxy.Listen, yellowColor, proxy.Upstream, enabledColor(proxy.Enabled), proxy.Name, noColor)
+				}
+			},
+		},
+		{
+			Name:    "inspect",
+			Aliases: []string{"i", "ins"},
+			Usage:   "Inspect a single proxy",
+			Action: func(c *cli.Context) {
+				proxyName := c.Args().First()
+
+				proxy, err := toxiproxyClient.Proxy(proxyName)
+				if err != nil {
+					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+					os.Exit(1)
+				}
+
+				// TODO It would be cool to include the enabled toxics in the pipe
+				// rendering --L-SC-> for latency + slow close enabled
+				fmt.Printf("%s%s%s\n", enabledColor(proxy.Enabled), proxy.Name, noColor)
+				fmt.Printf("%s%s %s---> %s%s%s\n\n", blueColor, proxy.Listen, grayColor, yellowColor, proxy.Upstream, noColor)
+
+				listToxics(proxy.ToxicsUpstream, "upstream")
+				fmt.Println()
+				listToxics(proxy.ToxicsDownstream, "downstream")
+			},
+		},
+		{
+			Name:    "toggle",
+			Usage:   "Toggle enabled status on a proxy",
+			Aliases: []string{"tog"},
+			Action: func(c *cli.Context) {
+				proxyName := c.Args().First()
+
+				proxy, err := toxiproxyClient.Proxy(proxyName)
+				if err != nil {
+					fmt.Printf("Failed to retrieve proxy %s: %s\n", proxyName, err.Error())
+					os.Exit(1)
+				}
+
+				proxy.Enabled = !proxy.Enabled
+
+				err = proxy.Save()
+				if err != nil {
+					fmt.Printf("Failed to toggle proxy %s: %s\n", proxyName, err.Error())
+					os.Exit(1)
+				}
+
+				fmt.Printf("Proxy %s%s%s is now %s%s%s\n", enabledColor(proxy.Enabled), proxyName, noColor, enabledColor(proxy.Enabled), enabledText(proxy.Enabled), noColor)
+			},
+		},
+	}
+
+	app.Run(os.Args)
+}
+
+func enabledColor(enabled bool) string {
+	if enabled {
+		return "\x1b[32m"
+	}
+
+	return "\x1b[31m"
+}
+
+func enabledText(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+
+	return "disabled"
+}
+
+func listToxics(toxics toxiproxy.Toxics, direction string) {
+	for name, toxic := range toxics {
+		fmt.Printf("%s%s direction=%s", enabledColor(toxic["enabled"].(bool)), name, direction)
+
+		for property, value := range toxic {
+			fmt.Printf(" %s=", property)
+			fmt.Print(value)
+		}
+		fmt.Println()
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -240,6 +240,9 @@ func (proxy *Proxy) Toxics() (Toxics, error) {
 // See https://github.com/Shopify/toxiproxy#toxics for a list of all Toxic types.
 func (proxy *Proxy) AddToxic(name, typeName, stream string, toxicity float32, attrs Attributes) (*Toxic, error) {
 	toxic := Toxic{name, typeName, stream, toxicity, attrs}
+	if toxic.Toxicity == -1 {
+		toxic.Toxicity = 1 // Just to be consistent with a toxicity of -1 using the default
+	}
 
 	request, err := json.Marshal(&toxic)
 	if err != nil {
@@ -266,8 +269,14 @@ func (proxy *Proxy) AddToxic(name, typeName, stream string, toxicity float32, at
 }
 
 // UpdateToxic sets the parameters for an existing toxic with the given name.
+// If toxicity is set to -1, the current value will be used.
 func (proxy *Proxy) UpdateToxic(name string, toxicity float32, attrs Attributes) (*Toxic, error) {
-	toxic := Toxic{Toxicity: toxicity, Attributes: attrs}
+	toxic := map[string]interface{}{
+		"attributes": attrs,
+	}
+	if toxicity != -1 {
+		toxic["toxicity"] = toxicity
+	}
 	request, err := json.Marshal(&toxic)
 	if err != nil {
 		return nil, err

--- a/link.go
+++ b/link.go
@@ -58,10 +58,9 @@ func (link *ToxicLink) Start(name string, source io.Reader, dest io.WriteCloser)
 		bytes, err := io.Copy(link.input, source)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
-				"name":     link.proxy.Name,
-				"upstream": link.proxy.Upstream,
-				"bytes":    bytes,
-				"err":      err,
+				"name":  link.proxy.Name,
+				"bytes": bytes,
+				"err":   err,
 			}).Warn("Source terminated")
 		}
 		link.input.Close()
@@ -73,10 +72,9 @@ func (link *ToxicLink) Start(name string, source io.Reader, dest io.WriteCloser)
 		bytes, err := io.Copy(dest, link.output)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
-				"name":     link.proxy.Name,
-				"upstream": link.proxy.Upstream,
-				"bytes":    bytes,
-				"err":      err,
+				"name":  link.proxy.Name,
+				"bytes": bytes,
+				"err":   err,
 			}).Warn("Destination terminated")
 		}
 		dest.Close()

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -158,9 +158,7 @@ func (c *ToxicCollection) UpdateToxicJson(name string, data io.Reader) (*toxics.
 				if err != nil {
 					return nil, joinError(err, ErrBadRequestBody)
 				}
-				if attrs.Toxicity != -1 {
-					toxic.Toxicity = attrs.Toxicity
-				}
+				toxic.Toxicity = attrs.Toxicity
 
 				c.chainUpdateToxic(toxic)
 				return toxic, nil

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -158,7 +158,9 @@ func (c *ToxicCollection) UpdateToxicJson(name string, data io.Reader) (*toxics.
 				if err != nil {
 					return nil, joinError(err, ErrBadRequestBody)
 				}
-				toxic.Toxicity = attrs.Toxicity
+				if attrs.Toxicity != -1 {
+					toxic.Toxicity = attrs.Toxicity
+				}
 
 				c.chainUpdateToxic(toxic)
 				return toxic, nil


### PR DESCRIPTION
Here's `toxiproxy-client` v2.0!

- [x] I should close both #58 and #91 as this PR replaces them.

Not worrying about clear commit history when doing rapid ux changes.
I'll start with a quick list of changes, followed by relevant screen shots.
1. Updated version number to 2.0
2. Removed graphic pipe in `inspect` because I found it confusing
3. Made `inspect` a lot clearer
4. Made `list` a lot clearer. Also table has `Toxic` and `Enabled` column
5. Added cyan hints (might be kinda silly?)
6. Added usage and examples to toplevel command and `toxic` command
7. Updated the `makefile` (@Sirupsen: would you glance at this, I'm a little rusty with make)

### Screen Shots
Part of the toplevel help screen.
![toplevel-help](https://cloud.githubusercontent.com/assets/5767836/12732016/9c11021c-c901-11e5-9be9-b1cb70ae6f78.png)
Part of the `./cli toxic` screen.
![toxic-help](https://cloud.githubusercontent.com/assets/5767836/12732039/b538f1f0-c901-11e5-9e8b-17bf61a30f11.png)
Looks like we havn't created any toxics yet...
![ls-empty](https://cloud.githubusercontent.com/assets/5767836/12732055/c4cf48b2-c901-11e5-8e16-b74e01d53dd5.png)
There's one!
![ls-one](https://cloud.githubusercontent.com/assets/5767836/12732064/cdfc7a18-c901-11e5-8186-a0ca48a7a8dc.png)
Let's try to inspect it!
![inspect-one](https://cloud.githubusercontent.com/assets/5767836/12732099/edc739d2-c901-11e5-821a-df7d01636948.png)
No toxics? Let's add one!
![inspect-down](https://cloud.githubusercontent.com/assets/5767836/12732167/49b5b746-c902-11e5-815e-06c646d3ae43.png)

Darn! It defaulted to downstream... let's add another upstream!
![inspect-up-down](https://cloud.githubusercontent.com/assets/5767836/12732120/06ce30a2-c902-11e5-935a-b9dc900fd07b.png)
And let's list the proxies again. **(This is after I added the enabled field)**
![with-enabled](https://cloud.githubusercontent.com/assets/5767836/12732199/78ef16b0-c902-11e5-932a-d6f165c3149c.png)


TODO:
- [x] #92 merge will require an update
- [ ] do I need to update the CHANGELOG?
- [x] ux review from @Sirupsen 
- [x] a ux review from someone who knows toxiproxy but not the client
- [x] Redo inspect command
- [ ] Configure toxiproxy host ip.
