### PR TITLE
latency toxic should reset Timestamp on output

### DIFF
--- a/toxics/latency.go
+++ b/toxics/latency.go
@@ -39,8 +39,10 @@ func (t *LatencyToxic) Pipe(stub *ToxicStub) {
 			sleep := t.delay() - time.Since(c.Timestamp)
 			select {
 			case <-time.After(sleep):
+				c.Timestamp = c.Timestamp.Add(sleep)
 				stub.Output <- c
 			case <-stub.Interrupt:
+				// Exit fast without applying latency.
 				stub.Output <- c // Don't drop any data on the floor
 				return
 			}


### PR DESCRIPTION
Multiple latency toxics previously did not stack their delays. Latency toxics now reset their data's `Timestamp` before output.

**Pros:** Easy fix that *just works*
**Cons:** Changing `Timestamp` state that might want to be used by other toxics in the future.

*Decided to create a new test rather than make the original latency test support multiple toxics.*

Sorry to ping you again @xthexder but you seem to know the most about this.
Also @Sirupsen, see https://github.com/Shopify/toxiproxy/pull/83#issuecomment-178224768 and https://github.com/Shopify/toxiproxy/pull/83#issuecomment-178221647