### PR TITLE
Embed toxic attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Define proxy buffer sizes per-toxic (Fixes #72)
 * Fix slicer toxic testing race condition #71
 * API and client return toxics as array rather than a map of name to toxic #92
+* Nest toxic attributes rather than having a flat structure #98
 
 # 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ For documentation on implementing custom toxics, see [CREATING_TOXICS.md](https:
 
 Add a delay to all data going through the proxy. The delay is equal to `latency` +/- `jitter`.
 
-Fields:
+Attributes:
 
  - `latency`: time in milliseconds
  - `jitter`: time in milliseconds
@@ -337,7 +337,7 @@ Toxiproxy. This is done by `POST`ing to `/proxies/{proxy}` and setting the
 
 Limit a connection to a maximum number of kilobytes per second.
 
-Fields:
+Attributes:
 
  - `rate`: rate in KB/s
 
@@ -345,7 +345,7 @@ Fields:
 
 Delay the TCP socket from closing until `delay` has elapsed.
 
-Fields:
+Attributes:
 
  - `delay`: time in milliseconds
 
@@ -355,7 +355,7 @@ Stops all data from getting through, and closes the connection after `timeout`. 
 `timeout` is 0, the connection won't close, and data will be delayed until the
 toxic is removed.
 
-Fields:
+Attributes:
 
  - `timeout`: time in milliseconds
 
@@ -364,7 +364,7 @@ Fields:
 Slices TCP data up into small bits, optionally adding a delay between each
 sliced "packet".
 
-Fields:
+Attributes:
 
  - `average_size`: size in bytes of an average packet
  - `size_variation`: variation in bytes of an average packet (should be smaller than average_size)
@@ -396,13 +396,13 @@ back to `true` to reenable it.
 
 #### Toxic fields:
 
- - `name`: toxic name (string, defaults to `type`)
+ - `name`: toxic name (string, defaults to `<type>_<stream>`)
  - `type`: toxic type (string)
  - `stream`: link direction to affect (defaults to `downstream`)
  - `toxicity`: probability of the toxic being applied to a link (defaults to 1.0, 100%)
+ - `attributes`: a map of toxic-specific attributes
 
-These are global fields that are applied to all toxics. Each toxic type has its own
-parameters that can be specified as well. See [Toxics](#toxics) for available types.
+See [Toxics](#toxics) for toxic-specific attributes.
 
 The `stream` direction must be either `upstream` or `downstream`. `upstream` applies
 the toxic on the `client -> server` connection, while `downstream` applies the toxic
@@ -431,10 +431,10 @@ All endpoints are JSON.
 $ curl -i -d '{"name": "redis", "upstream": "localhost:6379", "listen": "localhost:26379"}' localhost:8474/proxies
 HTTP/1.1 201 Created
 Content-Type: application/json
-Date: Fri, 21 Aug 2015 19:03:02 GMT
+Date: Fri, 18 Mar 2016 01:19:59 GMT
 Content-Length: 98
 
-{"name":"redis","listen":"127.0.0.1:26379","upstream":"localhost:6379","enabled":true,"toxics":{}}
+{"name":"redis","listen":"127.0.0.1:26379","upstream":"localhost:6379","enabled":true,"toxics":[]}
 ```
 
 ```bash
@@ -449,20 +449,20 @@ OK
 $ curl -i localhost:8474/proxies
 HTTP/1.1 200 OK
 Content-Type: application/json
-Date: Fri, 21 Aug 2015 19:04:23 GMT
+Date: Fri, 18 Mar 2016 01:20:31 GMT
 Content-Length: 108
 
-{"redis":{"name":"redis","listen":"127.0.0.1:26379","upstream":"localhost:6379","enabled":true,"toxics":{}}}
+{"redis":{"name":"redis","listen":"127.0.0.1:26379","upstream":"localhost:6379","enabled":true,"toxics":[]}}
 ```
 
 ```bash
-$ curl -i -d '{"type":"latency", "latency":1000}' localhost:8474/proxies/redis/toxics
+$ curl -i -d '{"type":"latency", "attributes":{"latency":1000}}' localhost:8474/proxies/redis/toxics
 HTTP/1.1 200 OK
 Content-Type: application/json
-Date: Fri, 21 Aug 2015 19:05:19 GMT
-Content-Length: 27
+Date: Fri, 18 Mar 2016 01:21:08 GMT
+Content-Length: 122
 
-{"latency":1000,"jitter":0}
+{"attributes":{"latency":1000,"jitter":0},"name":"latency_downstream","type":"latency","stream":"downstream","toxicity":1}
 ```
 
 ```bash
@@ -476,9 +476,9 @@ $ redis-cli -p 26379
 ```
 
 ```bash
-$ curl -i -X DELETE localhost:8474/proxies/redis/toxics/latency
+$ curl -i -X DELETE localhost:8474/proxies/redis/toxics/latency_downstream
 HTTP/1.1 204 No Content
-Date: Fri, 21 Aug 2015 19:06:28 GMT
+Date: Fri, 18 Mar 2016 01:21:58 GMT
 ```
 
 ```bash
@@ -490,7 +490,7 @@ $ redis-cli -p 26379
 ```bash
 $ curl -i -X DELETE localhost:8474/proxies/redis
 HTTP/1.1 204 No Content
-Date: Fri, 21 Aug 2015 19:07:07 GMT
+Date: Fri, 18 Mar 2016 01:22:20 GMT
 ```
 
 ```bash

--- a/api_test.go
+++ b/api_test.go
@@ -309,7 +309,7 @@ func TestResetState(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		latency, err := testProxy.AddToxic("", "latency", "downstream", tclient.Toxic{
+		latency, err := testProxy.AddToxic("", "latency", "downstream", 1, tclient.Attributes{
 			"latency": 100,
 			"jitter":  10,
 		})
@@ -317,7 +317,7 @@ func TestResetState(t *testing.T) {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
+		if latency.Attributes["latency"] != 100.0 || latency.Attributes["jitter"] != 10.0 {
 			t.Fatal("Latency toxic did not start up with correct settings")
 		}
 
@@ -373,7 +373,7 @@ func TestAddToxic(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		latency, err := testProxy.AddToxic("foobar", "latency", "downstream", tclient.Toxic{
+		latency, err := testProxy.AddToxic("foobar", "latency", "downstream", 1, tclient.Attributes{
 			"latency": 100,
 			"jitter":  10,
 		})
@@ -381,7 +381,7 @@ func TestAddToxic(t *testing.T) {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
+		if latency.Attributes["latency"] != 100.0 || latency.Attributes["jitter"] != 10.0 {
 			t.Fatal("Latency toxic did not start up with correct settings")
 		}
 
@@ -390,7 +390,7 @@ func TestAddToxic(t *testing.T) {
 			t.Fatal("Error returning toxics:", err)
 		}
 		toxic := AssertToxicExists(t, toxics, "foobar", "latency", "downstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 100.0 || toxic["jitter"] != 10.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 100.0 || toxic.Attributes["jitter"] != 10.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})
@@ -403,12 +403,12 @@ func TestAddMultipleToxics(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		_, err = testProxy.AddToxic("latency1", "latency", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("latency1", "latency", "downstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		_, err = testProxy.AddToxic("latency2", "latency", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("latency2", "latency", "downstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
@@ -419,7 +419,7 @@ func TestAddMultipleToxics(t *testing.T) {
 		}
 		AssertToxicExists(t, toxics, "latency1", "latency", "downstream", true)
 		toxic := AssertToxicExists(t, toxics, "latency2", "latency", "downstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 0.0 || toxic.Attributes["jitter"] != 0.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 		AssertToxicExists(t, toxics, "latency1", "", "upstream", false)
@@ -434,12 +434,12 @@ func TestAddConflictingToxic(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		_, err = testProxy.AddToxic("foobar", "latency", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("foobar", "latency", "downstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		_, err = testProxy.AddToxic("foobar", "slow_close", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("foobar", "slow_close", "downstream", 1, nil)
 		if err == nil {
 			t.Fatal("Toxic did not result in conflict.")
 		} else if err.Error() != "AddToxic: HTTP 409: toxic already exists" {
@@ -451,7 +451,7 @@ func TestAddConflictingToxic(t *testing.T) {
 			t.Fatal("Error returning toxics:", err)
 		}
 		toxic := AssertToxicExists(t, toxics, "foobar", "latency", "downstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 0.0 || toxic.Attributes["jitter"] != 0.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 		AssertToxicExists(t, toxics, "foobar", "", "upstream", false)
@@ -465,12 +465,12 @@ func TestAddConflictingToxicsMultistream(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		_, err = testProxy.AddToxic("foobar", "latency", "upstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("foobar", "latency", "upstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		_, err = testProxy.AddToxic("foobar", "latency", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("foobar", "latency", "downstream", 1, nil)
 		if err == nil {
 			t.Fatal("Toxic did not result in conflict.")
 		} else if err.Error() != "AddToxic: HTTP 409: toxic already exists" {
@@ -481,8 +481,9 @@ func TestAddConflictingToxicsMultistream(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
+
 		toxic := AssertToxicExists(t, toxics, "foobar", "latency", "upstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 0.0 || toxic.Attributes["jitter"] != 0.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 		AssertToxicExists(t, toxics, "foobar", "", "downstream", false)
@@ -496,12 +497,12 @@ func TestAddConflictingToxicsMultistreamDefaults(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		_, err = testProxy.AddToxic("", "latency", "upstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("", "latency", "upstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		_, err = testProxy.AddToxic("", "latency", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("", "latency", "downstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
@@ -511,11 +512,11 @@ func TestAddConflictingToxicsMultistreamDefaults(t *testing.T) {
 			t.Fatal("Error returning toxics:", err)
 		}
 		toxic := AssertToxicExists(t, toxics, "latency_upstream", "latency", "upstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 0.0 || toxic.Attributes["jitter"] != 0.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 		toxic = AssertToxicExists(t, toxics, "latency_downstream", "latency", "downstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 0.0 || toxic.Attributes["jitter"] != 0.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})
@@ -528,16 +529,15 @@ func TestAddToxicWithToxicity(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		latency, err := testProxy.AddToxic("", "latency", "downstream", tclient.Toxic{
-			"latency":  100,
-			"jitter":   10,
-			"toxicity": 0.2,
+		latency, err := testProxy.AddToxic("", "latency", "downstream", 0.2, tclient.Attributes{
+			"latency": 100,
+			"jitter":  10,
 		})
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["toxicity"] != 0.2 || latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
+		if latency.Toxicity != 0.2 || latency.Attributes["latency"] != 100.0 || latency.Attributes["jitter"] != 10.0 {
 			t.Fatal("Latency toxic did not start up with correct settings:", latency)
 		}
 
@@ -546,7 +546,7 @@ func TestAddToxicWithToxicity(t *testing.T) {
 			t.Fatal("Error returning toxics:", err)
 		}
 		toxic := AssertToxicExists(t, toxics, "latency_downstream", "latency", "downstream", true)
-		if toxic["toxicity"] != 0.2 || toxic["latency"] != 100.0 || toxic["jitter"] != 10.0 {
+		if toxic.Toxicity != 0.2 || toxic.Attributes["latency"] != 100.0 || toxic.Attributes["jitter"] != 10.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})
@@ -559,12 +559,12 @@ func TestAddNoop(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		noop, err := testProxy.AddToxic("foobar", "noop", "", nil)
+		noop, err := testProxy.AddToxic("foobar", "noop", "", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if noop["toxicity"] != 1.0 || noop["name"] != "foobar" || noop["type"] != "noop" || noop["stream"] != "downstream" {
+		if noop.Toxicity != 1.0 || noop.Name != "foobar" || noop.Type != "noop" || noop.Stream != "downstream" {
 			t.Fatal("Noop toxic did not start up with correct settings:", noop)
 		}
 
@@ -573,7 +573,7 @@ func TestAddNoop(t *testing.T) {
 			t.Fatal("Error returning toxics:", err)
 		}
 		toxic := AssertToxicExists(t, toxics, "foobar", "noop", "downstream", true)
-		if toxic["toxicity"] != 1.0 {
+		if toxic.Toxicity != 1.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})
@@ -586,7 +586,7 @@ func TestUpdateToxics(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		latency, err := testProxy.AddToxic("", "latency", "downstream", tclient.Toxic{
+		latency, err := testProxy.AddToxic("", "latency", "downstream", 1, tclient.Attributes{
 			"latency": 100,
 			"jitter":  10,
 		})
@@ -594,19 +594,18 @@ func TestUpdateToxics(t *testing.T) {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["toxicity"] != 1.0 || latency["latency"] != 100.0 || latency["jitter"] != 10.0 {
+		if latency.Toxicity != 1.0 || latency.Attributes["latency"] != 100.0 || latency.Attributes["jitter"] != 10.0 {
 			t.Fatal("Latency toxic did not start up with correct settings:", latency)
 		}
 
-		latency, err = testProxy.UpdateToxic("latency_downstream", tclient.Toxic{
-			"latency":  1000,
-			"toxicity": 0.5,
+		latency, err = testProxy.UpdateToxic("latency_downstream", 0.5, tclient.Attributes{
+			"latency": 1000,
 		})
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 
-		if latency["toxicity"] != 0.5 || latency["latency"] != 1000.0 || latency["jitter"] != 10.0 {
+		if latency.Toxicity != 0.5 || latency.Attributes["latency"] != 1000.0 || latency.Attributes["jitter"] != 10.0 {
 			t.Fatal("Latency toxic did not get updated with the correct settings:", latency)
 		}
 
@@ -614,8 +613,9 @@ func TestUpdateToxics(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
+
 		toxic := AssertToxicExists(t, toxics, "latency_downstream", "latency", "downstream", true)
-		if toxic["toxicity"] != 0.5 || toxic["latency"] != 1000.0 || toxic["jitter"] != 10.0 {
+		if toxic.Toxicity != 0.5 || toxic.Attributes["latency"] != 1000.0 || toxic.Attributes["jitter"] != 10.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 	})
@@ -628,7 +628,7 @@ func TestRemoveToxic(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		_, err = testProxy.AddToxic("", "latency", "downstream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("", "latency", "downstream", 1, nil)
 		if err != nil {
 			t.Fatal("Error setting toxic:", err)
 		}
@@ -637,8 +637,9 @@ func TestRemoveToxic(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error returning toxics:", err)
 		}
+
 		toxic := AssertToxicExists(t, toxics, "latency_downstream", "latency", "downstream", true)
-		if toxic["toxicity"] != 1.0 || toxic["latency"] != 0.0 || toxic["jitter"] != 0.0 {
+		if toxic.Toxicity != 1.0 || toxic.Attributes["latency"] != 0.0 || toxic.Attributes["jitter"] != 0.0 {
 			t.Fatal("Toxic was not read back correctly:", toxic)
 		}
 
@@ -680,32 +681,28 @@ func TestInvalidStream(t *testing.T) {
 			t.Fatal("Unable to create proxy:", err)
 		}
 
-		_, err = testProxy.AddToxic("", "latency", "walrustream", tclient.Toxic{})
+		_, err = testProxy.AddToxic("", "latency", "walrustream", 1, nil)
 		if err == nil {
 			t.Fatal("Error setting toxic:", err)
 		}
 	})
 }
 
-func findToxic(t *testing.T, name string, toxics tclient.Toxics) (tclient.Toxic, bool) {
+func findToxic(t *testing.T, name string, toxics tclient.Toxics) (*tclient.Toxic, bool) {
 	for _, tox := range toxics {
-		n, ok := tox["name"]
-		if !ok {
-			t.Fatal("expected toxic to have name field")
-		}
-		if name == n {
-			return tox, true
+		if name == tox.Name {
+			return &tox, true
 		}
 	}
 	return nil, false
 }
 
-func AssertToxicExists(t *testing.T, toxics tclient.Toxics, name, typeName, stream string, exists bool) tclient.Toxic {
+func AssertToxicExists(t *testing.T, toxics tclient.Toxics, name, typeName, stream string, exists bool) *tclient.Toxic {
 	toxic, found := findToxic(t, name, toxics)
 	var actualType, actualStream string
 	if found {
-		actualType = toxic["type"].(string)
-		actualStream = toxic["stream"].(string)
+		actualType = toxic.Type
+		actualStream = toxic.Stream
 	}
 	if exists {
 		if !found {

--- a/api_test.go
+++ b/api_test.go
@@ -688,31 +688,26 @@ func TestInvalidStream(t *testing.T) {
 	})
 }
 
-func findToxic(t *testing.T, name string, toxics tclient.Toxics) (*tclient.Toxic, bool) {
+func AssertToxicExists(t *testing.T, toxics tclient.Toxics, name, typeName, stream string, exists bool) *tclient.Toxic {
+	var toxic *tclient.Toxic
+	var actualType, actualStream string
+
 	for _, tox := range toxics {
 		if name == tox.Name {
-			return &tox, true
+			toxic = &tox
+			actualType = tox.Type
+			actualStream = tox.Stream
 		}
 	}
-	return nil, false
-}
-
-func AssertToxicExists(t *testing.T, toxics tclient.Toxics, name, typeName, stream string, exists bool) *tclient.Toxic {
-	toxic, found := findToxic(t, name, toxics)
-	var actualType, actualStream string
-	if found {
-		actualType = toxic.Type
-		actualStream = toxic.Stream
-	}
 	if exists {
-		if !found {
+		if toxic == nil {
 			t.Fatalf("Expected to see %s toxic in list", name)
 		} else if actualType != typeName {
 			t.Fatalf("Expected %s to be of type %s, found %s", name, typeName, actualType)
 		} else if actualStream != stream {
 			t.Fatalf("Expected %s to be in stream %s, found %s", name, stream, actualStream)
 		}
-	} else if found && actualStream == stream {
+	} else if toxic != nil && actualStream == stream {
 		t.Fatalf("Expected %s toxic to be missing from list, found type %s", name, actualType)
 	}
 	return toxic

--- a/client/README.md
+++ b/client/README.md
@@ -59,13 +59,13 @@ proxies, err = client.Populate(config)
 
 Toxics can be added as follows:
 ```go
-// Add 1s latency to the downstream
-proxy.AddToxic("latency_down", "latency", "downstream", toxiproxy.Toxic{
+// Add 1s latency to 100% of downstream connections
+proxy.AddToxic("latency_down", "latency", "downstream", 1.0, toxiproxy.Attributes{
     "latency": 1000,
 })
 
 // Change downstream latency to add 100ms of jitter
-proxy.UpdateToxic("latency_down", toxiproxy.Toxic{
+proxy.UpdateToxic("latency_down", 1.0, toxiproxy.Attributes{
     "jitter": 100,
 })
 
@@ -126,10 +126,10 @@ func TestRedisBackendDown(t *testing.T) {
 }
 
 func TestRedisBackendSlow(t *testing.T) {
-    proxies["redis"].AddToxic("", "latency", "", toxiproxy.Toxic{
+    proxies["redis"].AddToxic("", "latency", "", 1, toxiproxy.Attributes{
         "latency": 1000,
     })
-    defer proxies["redis"].RemoveToxic("latency")
+    defer proxies["redis"].RemoveToxic("latency_downstream")
 
     // Test that redis is slow
     start := time.Now()

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -1,7 +1,6 @@
 package toxics
 
 import (
-	"encoding/json"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -33,7 +32,7 @@ type BufferedToxic interface {
 }
 
 type ToxicWrapper struct {
-	Toxic      `json:"-"`
+	Toxic      `json:"attributes"`
 	Name       string           `json:"name"`
 	Type       string           `json:"type"`
 	Stream     string           `json:"stream"`
@@ -41,25 +40,6 @@ type ToxicWrapper struct {
 	Direction  stream.Direction `json:"-"`
 	Index      int              `json:"-"`
 	BufferSize int              `json:"-"`
-}
-
-// Marhsal toxics to include both the Toxic and ToxicWrapper fields
-func (w *ToxicWrapper) MarshalJSON() ([]byte, error) {
-	toxic, err := json.Marshal(w.Toxic)
-	if err != nil {
-		return nil, err
-	}
-	wrapper, err := json.Marshal(*w)
-	if err != nil {
-		return nil, err
-	}
-	output := wrapper[:len(wrapper)-1]
-	if len(toxic) > 2 {
-		output = append(output, ',')
-		output = append(output, toxic[1:len(toxic)-1]...)
-	}
-	output = append(output, '}')
-	return output, nil
 }
 
 type ToxicStub struct {

--- a/toxics/toxic_test.go
+++ b/toxics/toxic_test.go
@@ -90,39 +90,18 @@ func WithEchoProxy(t *testing.T, f func(proxy net.Conn, response chan []byte, pr
 }
 
 func ToxicToJson(t *testing.T, name, typeName, stream string, toxic toxics.Toxic) io.Reader {
-	// Hack to add fields to an interface, json will nest otherwise, not embed
-	data, err := json.Marshal(toxic)
+	data := map[string]interface{}{
+		"name":       name,
+		"type":       typeName,
+		"stream":     stream,
+		"attributes": toxic,
+	}
+	request, err := json.Marshal(data)
 	if err != nil {
-		if t != nil {
-			t.Errorf("Failed to marshal toxic for api (1): %v", toxic)
-		}
-		return nil
+		t.Errorf("Failed to marshal toxic for api (1): %v", toxic)
 	}
 
-	marshal := make(map[string]interface{})
-	err = json.Unmarshal(data, &marshal)
-	if err != nil {
-		if t != nil {
-			t.Errorf("Failed to unmarshal toxic (2): %v", toxic)
-		}
-		return nil
-	}
-	marshal["type"] = typeName
-	if name != "" {
-		marshal["name"] = name
-	}
-	if stream != "" {
-		marshal["stream"] = stream
-	}
-
-	data, err = json.Marshal(marshal)
-	if err != nil {
-		if t != nil {
-			t.Errorf("Failed to marshal toxic for api (3): %v", toxic)
-		}
-		return nil
-	}
-	return bytes.NewReader(data)
+	return bytes.NewReader(request)
 }
 
 func AssertEchoResponse(t *testing.T, client, server net.Conn) {


### PR DESCRIPTION
This patch embeds toxic specific attributes into their own nested `attributes` field, allowing for the following api changes:
``` go
type Attributes map[string]interface{}

type Toxic struct {
	Name       string     `json:"name"`
	Type       string     `json:"type"`
	Stream     string     `json:"stream"`
	Toxicity   float32    `json:"toxicity"`
	Attributes Attributes `json:"attributes"`
}

AddToxic(name, typeName, stream string, toxicity float32, attrs Attributes)
UpdateToxic(name string, toxicity float32, attrs Attributes)
```
We can't marshal the attributes of a toxic until we know what kind of toxic struct to marshal into. This has previously forced us to [parse the json twice](https://github.com/Shopify/toxiproxy/blob/d21a2744e6275eb5312b11ab978656fd7cad50bc/toxic_collection.go#L95).

I can't think of a better solution than to [use an anonymous struct](https://github.com/Shopify/toxiproxy/blob/d21a2744e6275eb5312b11ab978656fd7cad50bc/toxic_collection.go#L129-L138) to extract the specific json that we need.

This has also caused the previous toxic marsheling to be kinda sketchy. [My change does not make it less sketchy](https://github.com/Shopify/toxiproxy/blob/d21a2744e6275eb5312b11ab978656fd7cad50bc/toxics/toxic.go#L57-L60).

I'm happy enough with the approach. There might not be a pretty solution. @Sirupsen or @xthexder might be able to think of one?

Update *CHANGELOG*, docs and squish the commits once we're ready to merge.



