### PR TITLE
Add a populate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2.1.0 (Unreleased)
 
+* Add `/populate` endpoint to server #111
+* Change error responses from `title` to `error`
 * Allow hostname to be specified in CLI #129
 * Add support for stateful toxics #127
 * Add limit_data toxic

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ stopping you from creating a client in any other language (see
   1. [Proxy fields](#proxy-fields)
   2. [Toxic fields](#toxic-fields)
   3. [Endpoints](#endpoints)
+  4. [Populating Proxies](#populating-proxies)
 7. [CLI example](#cli-example)
 8. [FAQ](#frequently-asked-questions)
 9. [Development](#development)
@@ -440,6 +441,16 @@ All endpoints are JSON.
  - **DELETE /proxies/{proxy}/toxics/{toxic}** - Remove an active toxic
  - **POST /reset** - Enable all proxies and remove all active toxics
  - **GET /version** - Returns the server version number
+
+#### Populating Proxies
+
+Proxies can be added and configured in bulk using the `/populate` endpoint. This is done by
+passing an json array of proxies to toxiproxy. If a proxy with the same name already exists,
+it will be compared to the new proxy and replaced if the `upstream` and `listen` address don't match.
+
+A `/populate` call can be included for example at application start to ensure all required proxies
+exist. It is safe to make this call several times, since proxies will be untouched as long as their
+fields are consistent with the new data.
 
 ### CLI Example
 

--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ All endpoints are JSON.
 
  - **GET /proxies** - List existing proxies and their toxics
  - **POST /proxies** - Create a new proxy
+ - **POST /populate** - Create or replace a list of proxies
  - **GET /proxies/{proxy}** - Show the proxy with all its active toxics
  - **POST /proxies/{proxy}** - Update a proxy's fields
  - **DELETE /proxies/{proxy}** - Delete an existing proxy

--- a/api.go
+++ b/api.go
@@ -146,11 +146,11 @@ func (server *ApiServer) Populate(response http.ResponseWriter, request *http.Re
 	t := true
 	for i, p := range input {
 		if len(p.Name) < 1 {
-			apiError(response, joinError(fmt.Errorf("name"), ErrMissingField))
+			apiError(response, joinError(fmt.Errorf("name at proxy %d", i+1), ErrMissingField))
 			return
 		}
 		if len(p.Upstream) < 1 {
-			apiError(response, joinError(fmt.Errorf("upstream"), ErrMissingField))
+			apiError(response, joinError(fmt.Errorf("upstream at proxy %d", i+1), ErrMissingField))
 			return
 		}
 		if p.Enabled == nil {

--- a/api_test.go
+++ b/api_test.go
@@ -1,9 +1,9 @@
 package toxiproxy_test
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
@@ -74,51 +74,186 @@ func TestCreateProxyBlankUpstream(t *testing.T) {
 
 func TestPopulateProxy(t *testing.T) {
 	WithServer(t, func(addr string) {
-		testProxies, err := client.Populate2([]tclient.Proxy{
+		testProxies, err := client.Populate([]tclient.Proxy{
 			{
 				Name:     "one",
 				Listen:   "localhost:7070",
 				Upstream: "localhost:7171",
+				Enabled:  true,
 			},
 			{
 				Name:     "two",
 				Listen:   "localhost:7373",
 				Upstream: "localhost:7474",
+				Enabled:  true,
 			},
 		})
+
+		if err != nil {
+			t.Fatal("Unable to populate:", err)
+		} else if len(testProxies) != 2 {
+			t.Fatalf("Wrong number of proxies returned: %d != 2", len(testProxies))
+		} else if testProxies[0].Name != "one" || testProxies[1].Name != "two" {
+			t.Fatalf("Wrong proxy names returned: %s, %s", testProxies[0].Name, testProxies[1].Name)
+		}
 
 		for _, p := range testProxies {
 			AssertProxyUp(t, p.Listen, true)
 		}
+	})
+}
 
+func TestPopulateDefaultEnabled(t *testing.T) {
+	WithServer(t, func(addr string) {
+		request := []byte(`[{"name": "test", "listen": "localhost:7070", "upstream": "localhost:7171"}]`)
+
+		resp, err := http.Post(addr+"/populate", "application/json", bytes.NewReader(request))
 		if err != nil {
-			t.Fatal("Unable to populate:", err)
+			t.Fatal("Failed to send POST to /populate:", err)
+		}
+
+		if resp.StatusCode != http.StatusCreated {
+			message, _ := ioutil.ReadAll(resp.Body)
+			t.Fatalf("Failed to populate proxy list: HTTP %s\n%s", resp.Status, string(message))
+		}
+
+		proxies, err := client.Proxies()
+		if err != nil {
+			t.Fatal(err)
+		} else if len(proxies) != 1 {
+			t.Fatalf("Wrong number of proxies created: %d != 1", len(proxies))
+		} else if _, ok := proxies["test"]; !ok {
+			t.Fatalf("Wrong proxy name returned")
+		}
+
+		for _, p := range proxies {
+			AssertProxyUp(t, p.Listen, true)
 		}
 	})
 }
 
-func TestPopulateProxyWithBadDataShouldBeTransactional(t *testing.T) {
+func TestPopulateExistingProxy(t *testing.T) {
 	WithServer(t, func(addr string) {
-		_, err := client.Populate2([]tclient.Proxy{
+		testProxy, err := client.CreateProxy("one", "localhost:7070", "localhost:7171")
+		if err != nil {
+			t.Fatal("Unable to create proxy:", err)
+		}
+		_, err = client.CreateProxy("two", "localhost:7373", "localhost:7474")
+		if err != nil {
+			t.Fatal("Unable to create proxy:", err)
+		}
+
+		// Create a toxic so we can make sure the proxy wasn't replaced
+		_, err = testProxy.AddToxic("", "latency", "downstream", 1, nil)
+		if err != nil {
+			t.Fatal("Unable to create toxic:", err)
+		}
+
+		testProxies, err := client.Populate([]tclient.Proxy{
+			{
+				Name:     "one",
+				Listen:   "127.0.0.1:7070", // TODO(xthexder): Will replace existing proxy if not resolved ip...
+				Upstream: "localhost:7171",
+				Enabled:  true,
+			},
+			{
+				Name:     "two",
+				Listen:   "127.0.0.1:7575",
+				Upstream: "localhost:7676",
+				Enabled:  true,
+			},
+		})
+
+		if err != nil {
+			t.Fatal("Unable to populate:", err)
+		} else if len(testProxies) != 2 {
+			t.Fatalf("Wrong number of proxies returned: %d != 2", len(testProxies))
+		} else if testProxies[0].Name != "one" || testProxies[1].Name != "two" {
+			t.Fatalf("Wrong proxy names returned: %s, %s", testProxies[0].Name, testProxies[1].Name)
+		} else if testProxies[0].Listen != "127.0.0.1:7070" || testProxies[1].Listen != "127.0.0.1:7575" {
+			t.Fatalf("Wrong proxy listen addresses returned: %s, %s", testProxies[0].Listen, testProxies[1].Listen)
+		}
+
+		toxics, err := testProxy.Toxics()
+		if err != nil {
+			t.Fatal("Unable to get toxics:", err)
+		}
+		if len(toxics) != 1 || toxics[0].Type != "latency" {
+			t.Fatalf("Populate did not preseve existing proxy. (%d toxics)", len(toxics))
+		}
+
+		for _, p := range testProxies {
+			AssertProxyUp(t, p.Listen, true)
+		}
+	})
+}
+
+func TestPopulateWithBadName(t *testing.T) {
+	WithServer(t, func(addr string) {
+		testProxies, err := client.Populate([]tclient.Proxy{
 			{
 				Name:     "one",
 				Listen:   "localhost:7070",
 				Upstream: "localhost:7171",
+				Enabled:  true,
 			},
 			{
-				Name:     "two",
-				Listen:   "local373",
-				Upstream: "localhost:7474",
-			},
-			{
-				Name:     "three",
-				Listen:   "localhost:7575",
-				Upstream: "localhost:7676",
+				Name:    "",
+				Listen:  "",
+				Enabled: true,
 			},
 		})
 
 		if err == nil {
 			t.Fatal("Expected Populate to fail.")
+		} else if err.Error() != "Populate: HTTP 400: missing required field: name" {
+			t.Fatal("Expected different error during populate:", err)
+		} else if len(testProxies) != 0 {
+			t.Fatalf("Wrong number of proxies returned: %d != 0", len(testProxies))
+		}
+
+		proxies, err := client.Proxies()
+		if err != nil {
+			t.Fatal(err)
+		} else if len(proxies) != 0 {
+			t.Fatalf("Expected no proxies to be created: %d != 0", len(proxies))
+		}
+	})
+}
+
+func TestPopulateProxyWithBadDataShouldReturnError(t *testing.T) {
+	WithServer(t, func(addr string) {
+		testProxies, err := client.Populate([]tclient.Proxy{
+			{
+				Name:     "one",
+				Listen:   "localhost:7070",
+				Upstream: "localhost:7171",
+				Enabled:  true,
+			},
+			{
+				Name:     "two",
+				Listen:   "local373",
+				Upstream: "localhost:7474",
+				Enabled:  true,
+			},
+			{
+				Name:     "three",
+				Listen:   "localhost:7575",
+				Upstream: "localhost:7676",
+				Enabled:  true,
+			},
+		})
+
+		if err == nil {
+			t.Fatal("Expected Populate to fail.")
+		} else if len(testProxies) != 1 {
+			t.Fatalf("Wrong number of proxies returned: %d != %d", len(testProxies), 1)
+		} else if testProxies[0].Name != "one" {
+			t.Fatalf("Wrong proxy name returned: %s != one", testProxies[0].Name)
+		}
+
+		for _, p := range testProxies {
+			AssertProxyUp(t, p.Listen, true)
 		}
 
 		proxies, err := client.Proxies()
@@ -127,8 +262,8 @@ func TestPopulateProxyWithBadDataShouldBeTransactional(t *testing.T) {
 		}
 
 		for _, p := range proxies {
-			if p.Name == "one" || p.Name == "two" || p.Name == "three" {
-				t.Fatalf("Proxy %s was still exists. Populate was not transactional.")
+			if p.Name == "two" || p.Name == "three" {
+				t.Fatalf("Proxy %s exists, populate did not fail correctly.")
 			}
 		}
 	})
@@ -758,42 +893,6 @@ func TestInvalidStream(t *testing.T) {
 		_, err = testProxy.AddToxic("", "latency", "walrustream", 1, nil)
 		if err == nil {
 			t.Fatal("Error setting toxic:", err)
-		}
-	})
-}
-
-func BenchmarkPopulateProxyList(b *testing.B) {
-	WithServer(nil, func(addr string) {
-		proxyList := make([]tclient.Proxy, b.N)
-		for i := 0; i < len(proxyList); i++ {
-			proxyList[i] = tclient.Proxy{
-				Name:     "test" + strconv.Itoa(i),
-				Listen:   "127.0.0.1:0",
-				Upstream: "localhost:7171",
-			}
-		}
-		_, err := client.Populate(proxyList)
-
-		if err != nil {
-			b.Fatal("Unable to populate:", err)
-		}
-	})
-}
-
-func BenchmarkPopulateProxyList2(b *testing.B) {
-	WithServer(nil, func(addr string) {
-		proxyList := make([]tclient.Proxy, b.N)
-		for i := 0; i < len(proxyList); i++ {
-			proxyList[i] = tclient.Proxy{
-				Name:     "test" + strconv.Itoa(i),
-				Listen:   "127.0.0.1:0",
-				Upstream: "localhost:7171",
-			}
-		}
-		_, err := client.Populate2(proxyList)
-
-		if err != nil {
-			b.Fatal("Unable to populate:", err)
 		}
 	})
 }

--- a/api_test.go
+++ b/api_test.go
@@ -3,6 +3,7 @@ package toxiproxy_test
 import (
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -757,6 +758,42 @@ func TestInvalidStream(t *testing.T) {
 		_, err = testProxy.AddToxic("", "latency", "walrustream", 1, nil)
 		if err == nil {
 			t.Fatal("Error setting toxic:", err)
+		}
+	})
+}
+
+func BenchmarkPopulateProxyList(b *testing.B) {
+	WithServer(nil, func(addr string) {
+		proxyList := make([]tclient.Proxy, b.N)
+		for i := 0; i < len(proxyList); i++ {
+			proxyList[i] = tclient.Proxy{
+				Name:     "test" + strconv.Itoa(i),
+				Listen:   "127.0.0.1:0",
+				Upstream: "localhost:7171",
+			}
+		}
+		_, err := client.Populate(proxyList)
+
+		if err != nil {
+			b.Fatal("Unable to populate:", err)
+		}
+	})
+}
+
+func BenchmarkPopulateProxyList2(b *testing.B) {
+	WithServer(nil, func(addr string) {
+		proxyList := make([]tclient.Proxy, b.N)
+		for i := 0; i < len(proxyList); i++ {
+			proxyList[i] = tclient.Proxy{
+				Name:     "test" + strconv.Itoa(i),
+				Listen:   "127.0.0.1:0",
+				Upstream: "localhost:7171",
+			}
+		}
+		_, err := client.Populate2(proxyList)
+
+		if err != nil {
+			b.Fatal("Unable to populate:", err)
 		}
 	})
 }

--- a/client/client.go
+++ b/client/client.go
@@ -147,6 +147,32 @@ func (client *Client) Populate(config []Proxy) (map[string]*Proxy, error) {
 	return proxies, nil
 }
 
+// TODO(jpittis) replace this with the old populate command.
+func (client *Client) Populate2(config []Proxy) ([]*Proxy, error) {
+	proxies := make([]*Proxy, len(config))
+	request, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post(client.endpoint+"/populate", "application/json", bytes.NewReader(request))
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkError(resp, http.StatusCreated, "Create")
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&proxies)
+	if err != nil {
+		return nil, err
+	}
+
+	return proxies, nil
+}
+
 // Save saves changes to a proxy such as its enabled status or upstream port.
 func (proxy *Proxy) Save() error {
 	request, err := json.Marshal(proxy)

--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -29,7 +31,6 @@ type Toxic struct {
 
 type Toxics []Toxic
 
-// Proxy represents a Proxy.
 type Proxy struct {
 	Name     string `json:"name"`     // The name of the proxy
 	Listen   string `json:"listen"`   // The address the proxy listens on
@@ -130,26 +131,11 @@ func (client *Client) Proxy(name string) (*Proxy, error) {
 
 // Create a list of proxies using a configuration list. If a proxy already exists, it will be replaced
 // with the specified configuration. For large amounts of proxies, `config` can be loaded from a file.
-func (client *Client) Populate(config []Proxy) (map[string]*Proxy, error) {
-	proxies := make(map[string]*Proxy, len(config))
-	for _, proxy := range config {
-		existing, err := client.Proxy(proxy.Name)
-		if err != nil && err.Error() != "Proxy: HTTP 404: proxy not found" {
-			return nil, err
-		} else if existing != nil && (existing.Listen != proxy.Listen || existing.Upstream != proxy.Upstream) {
-			existing.Delete()
-		}
-		proxies[proxy.Name], err = client.CreateProxy(proxy.Name, proxy.Listen, proxy.Upstream)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return proxies, nil
-}
-
-// TODO(jpittis) replace this with the old populate command.
-func (client *Client) Populate2(config []Proxy) ([]*Proxy, error) {
-	proxies := make([]*Proxy, len(config))
+// Returns a list of the successfully created proxies.
+func (client *Client) Populate(config []Proxy) ([]*Proxy, error) {
+	proxies := struct {
+		Proxies []*Proxy `json:"proxies"`
+	}{}
 	request, err := json.Marshal(config)
 	if err != nil {
 		return nil, err
@@ -160,17 +146,17 @@ func (client *Client) Populate2(config []Proxy) ([]*Proxy, error) {
 		return nil, err
 	}
 
-	err = checkError(resp, http.StatusCreated, "Create")
+	// Response body may need to be read twice, we want to return both the proxy list and any errors
+	var body bytes.Buffer
+	tee := io.TeeReader(resp.Body, &body)
+	err = json.NewDecoder(tee).Decode(&proxies)
 	if err != nil {
 		return nil, err
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&proxies)
-	if err != nil {
-		return nil, err
-	}
-
-	return proxies, nil
+	resp.Body = ioutil.NopCloser(&body)
+	err = checkError(resp, http.StatusCreated, "Populate")
+	return proxies.Proxies, err
 }
 
 // Save saves changes to a proxy such as its enabled status or upstream port.
@@ -354,12 +340,12 @@ func (client *Client) ResetState() error {
 }
 
 type ApiError struct {
-	Title  string `json:"title"`
-	Status int    `json:"status"`
+	Message string `json:"error"`
+	Status  int    `json:"status"`
 }
 
 func (err *ApiError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", err.Status, err.Title)
+	return fmt.Sprintf("HTTP %d: %s", err.Status, err.Message)
 }
 
 func checkError(resp *http.Response, expectedCode int, caller string) error {
@@ -367,7 +353,7 @@ func checkError(resp *http.Response, expectedCode int, caller string) error {
 		apiError := new(ApiError)
 		err := json.NewDecoder(resp.Body).Decode(apiError)
 		if err != nil {
-			apiError.Title = fmt.Sprintf("Unexpected response code, expected %d", expectedCode)
+			apiError.Message = fmt.Sprintf("Unexpected response code, expected %d", expectedCode)
 			apiError.Status = resp.StatusCode
 		}
 		return fmt.Errorf("%s: %v", caller, apiError)

--- a/proxy.go
+++ b/proxy.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Shopify/toxiproxy/stream"
 	"github.com/Sirupsen/logrus"
-	"gopkg.in/tomb.v1"
+	tomb "gopkg.in/tomb.v1"
 
 	"net"
 )

--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -38,6 +38,29 @@ func (collection *ProxyCollection) Add(proxy *Proxy, start bool) error {
 	return nil
 }
 
+func (collection *ProxyCollection) AddOrReplace(proxy *Proxy, start bool) error {
+	collection.Lock()
+	defer collection.Unlock()
+
+	if existing, exists := collection.proxies[proxy.Name]; exists {
+		if existing.Listen == proxy.Listen && existing.Upstream == proxy.Upstream {
+			return nil
+		}
+		existing.Stop()
+	}
+
+	if start {
+		err := proxy.Start()
+		if err != nil {
+			return err
+		}
+	}
+
+	collection.proxies[proxy.Name] = proxy
+
+	return nil
+}
+
 func (collection *ProxyCollection) Proxies() map[string]*Proxy {
 	collection.RLock()
 	defer collection.RUnlock()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Shopify/toxiproxy"
 	"github.com/Sirupsen/logrus"
-	"gopkg.in/tomb.v1"
+	tomb "gopkg.in/tomb.v1"
 )
 
 func init() {
@@ -308,7 +308,7 @@ func TestRestartFailedToStartProxy(t *testing.T) {
 func AssertProxyUp(t *testing.T, addr string, up bool) net.Conn {
 	conn, err := net.Dial("tcp", addr)
 	if err != nil && up {
-		t.Error("Expected proxy to be up", err)
+		t.Error("Expected proxy to be up:", err)
 	} else if err == nil && !up {
 		t.Error("Expected proxy to be down")
 	}

--- a/toxics/toxic_test.go
+++ b/toxics/toxic_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Shopify/toxiproxy"
 	"github.com/Shopify/toxiproxy/toxics"
 	"github.com/Sirupsen/logrus"
-	"gopkg.in/tomb.v1"
+	tomb "gopkg.in/tomb.v1"
 )
 
 func init() {


### PR DESCRIPTION
Here's a WIP first draft for a Populate endpoint solving #102.
(The code can be made prettier and some names / types need to be changed to stick with the old API.)

The endpoint takes a slice of proxies, loop through them doing the standard CreateProxy code. If one of the proxies fails to be created, it deletes the already created proxies before returning the error to the user.

**Should we be making this transactional? There are current errors that can occur that won't trigger the transaction to fail.**

Hoping I could get a review of the general approach.
@Sirupsen @xthexder 
cc: @BlakeMesdag 