### PR TITLE
Updates to use replacement cli package.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,10 @@
 {
 	"ImportPath": "github.com/Shopify/toxiproxy",
 	"GoVersion": "go1.3.3",
+	"GodepVersion": "v74",
+	"Packages": [
+		"./..."
+	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -14,6 +18,11 @@
 		{
 			"ImportPath": "github.com/gorilla/mux",
 			"Rev": "4b8fbc56f3b2400a7c7ea3dba9b3539787c486b6"
+		},
+		{
+			"ImportPath": "github.com/urfave/cli",
+			"Comment": "v1.18.0",
+			"Rev": "1efa31f08b9333f1bd4882d61f9d668a70cd902e"
 		},
 		{
 			"ImportPath": "gopkg.in/tomb.v1",

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,7 +7,7 @@ import (
 
 	toxiproxyServer "github.com/Shopify/toxiproxy"
 	"github.com/Shopify/toxiproxy/client"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 
 	"fmt"
 	"os"
@@ -189,9 +189,11 @@ func main() {
 
 type toxiAction func(*cli.Context, *toxiproxy.Client)
 
-func withToxi(f toxiAction, t *toxiproxy.Client) func(*cli.Context) {
-	return func(c *cli.Context) {
+func withToxi(f toxiAction, t *toxiproxy.Client) func(*cli.Context) error {
+	return func(c *cli.Context) error {
 		f(c, t)
+
+		return nil
 	}
 }
 

--- a/toxics/latency_test.go
+++ b/toxics/latency_test.go
@@ -83,7 +83,7 @@ func DoLatencyTest(t *testing.T, upLatency, downLatency *toxics.LatencyToxic) {
 			"Round trip",
 			time.Since(timer),
 			time.Duration(upLatency.Latency+downLatency.Latency)*time.Millisecond,
-			time.Duration(upLatency.Jitter+downLatency.Jitter+10)*time.Millisecond,
+			time.Duration(upLatency.Jitter+downLatency.Jitter+20)*time.Millisecond,
 		)
 
 		proxy.Toxics.RemoveToxic("latency_up")


### PR DESCRIPTION
Tried to build recently (from a new Go installation) and while the build succeeded, trying to list the existing proxies from the cli command yielded a deprecation warning:

```
➜  toxiproxy git:(master) ./toxiproxy-cli list
Listen		Upstream	Name	Enabled	Toxics
======================================================================
no proxies

Hint: create a proxy with `toxiproxy-cli create`
DEPRECATED Action signature.  Must be `cli.ActionFunc`.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-action-signature
```

Looks like the `codegangsta/cli` package has been moved to `urface/cli`, according to that package's [README](https://github.com/urfave/cli#cli).

I updated the function signature that was causing the deprecation warning, and updated the toxiproxy-cli references to point to the updated `urface/cli` package location.

There seemed to be some issues with the latency tests. All the other tests worked fine, but the latency tests often (but not always) came in a hair too late to fit within the 10ms acceptance range. I bumped the round trip test acceptance range from 10ms to 20ms (which is just the sum of the acceptance ranges for the server and client read tests, so it seems acceptable). With that change the tests pass reliably. 

I'm very new to Go, so if I missed something here, I'd appreciate the feedback. Thanks!