### PR TITLE
Dockerfile: upgrade to go 1.7 and build the CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,10 @@
 FROM golang:1.7
 
-ADD . /app/src/github.com/Shopify/toxiproxy
+COPY . /go/src/github.com/Shopify/toxiproxy
 
-ENV GOPATH /app:$GOPATH
-ENV PATH $PATH:/app
-WORKDIR /app/src/github.com/Shopify/toxiproxy
-RUN go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat VERSION)" -o /app/toxiproxy ./cmd
-RUN go build -o /app/toxiproxy-cli ./cli
+RUN go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat /go/src/github.com/Shopify/toxiproxy/VERSION)" -o /go/bin/toxiproxy github.com/Shopify/toxiproxy/cmd && \
+    go build -o /go/bin/toxiproxy-cli github.com/Shopify/toxiproxy/cli
 
 EXPOSE 8474
-ENTRYPOINT ["/app/toxiproxy"]
+ENTRYPOINT ["/go/bin/toxiproxy"]
 CMD ["-host=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM golang:1.4
+FROM golang:1.7
 
 ADD . /app/src/github.com/Shopify/toxiproxy
-RUN cd /app/src/github.com/Shopify/toxiproxy && GOPATH=/app/src/github.com/Shopify/toxiproxy/Godeps/_workspace:/app go build -ldflags="-X github.com/Shopify/toxiproxy.Version $(cat VERSION)" -o /app/toxiproxy ./cmd
+
+ENV GOPATH /app:$GOPATH
+ENV PATH $PATH:/app
+WORKDIR /app/src/github.com/Shopify/toxiproxy
+RUN go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat VERSION)" -o /app/toxiproxy ./cmd
+RUN go build -o /app/toxiproxy-cli ./cli
 
 EXPOSE 8474
 ENTRYPOINT ["/app/toxiproxy"]


### PR DESCRIPTION
Upgrade Go version to 1.7, and also build the CLI.
Adapt GOPATH and PATH to launch the CLI directly from a `docker exec`