### PR TITLE
Add limit data toxic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.0 (Unreleased)
+
+* Add support for stateful toxics
+* Add limit_data toxic
+
 # 2.0.0
 
 * Add CLI (`toxiproxy-cli`) and rename server binary to `toxiproxy-server` #93

--- a/CREATING_TOXICS.md
+++ b/CREATING_TOXICS.md
@@ -115,6 +115,24 @@ The unit used by `GetBufferSize()` is `StreamChunk`s. Chunks are generally anywh
 1 byte, up to 32KB, so keep this in mind when thinking about how much buffering you need,
 and how much memory you are comfortable with using.
 
+## Stateful toxics
+
+If a toxic needs to store extra information for a connection such as the number of bytes
+transferred (See `limit_data` toxic), a state object can be created by implementing the
+`StatefulToxic` interface. This interface defines the `NewState()` function that can create
+a new state object with default values set.
+
+When a stateful toxic is created, the state object will be stored on the `ToxicStub` and
+can be accessed from `toxic.Pipe()`:
+
+```go
+state := stub.State.(*ExampleToxicState)
+```
+
+If necessary, some global state can be stored in the toxic struct, which will not be
+instanced per-connection. These fields cannot have a custom default value set and will
+not be thread-safe, so proper locking or atomic operations will need to be used.
+
 ## Using `io.Reader` and `io.Writer`
 
 If your toxic involves modifying the data going through a proxy, you can use the `ChanReader`

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ clean:
 	rm -f *.deb
 
 test:
+	echo "Testing with" `go version`
 	GOMAXPROCS=4 GOPATH=$(COMBINED_GOPATH) go test -v -race ./...
 
 tmp/build/$(SERVER_NAME)-linux-amd64:

--- a/README.md
+++ b/README.md
@@ -378,6 +378,12 @@ Attributes:
  - `size_variation`: variation in bytes of an average packet (should be smaller than average_size)
  - `delay`: time in microseconds to delay each packet by
 
+#### limit_data
+
+Closes connection when transmitted data exceeded limit.
+
+ - `bytes`: number of bytes it should transmit before connection is closed
+
 ### HTTP API
 
 All communication with the Toxiproxy daemon from the client happens through the

--- a/link_test.go
+++ b/link_test.go
@@ -207,7 +207,6 @@ func TestStateCreated(t *testing.T) {
 	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
 	collection.links["test"] = link
 
-	// Add stubs
 	collection.chainAddToxic(&toxics.ToxicWrapper{
 		Toxic:     new(toxics.LimitDataToxic),
 		Type:      "limit_data",

--- a/link_test.go
+++ b/link_test.go
@@ -200,3 +200,21 @@ func TestToxicity(t *testing.T) {
 		t.Fatalf("Read did not get EOF: %d %v", n, err)
 	}
 }
+
+func TestStateCreated(t *testing.T) {
+	collection := NewToxicCollection(nil)
+	link := NewToxicLink(nil, collection, stream.Downstream)
+	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
+	collection.links["test"] = link
+
+	// Add stubs
+	collection.chainAddToxic(&toxics.ToxicWrapper{
+		Toxic:     new(toxics.LimitDataToxic),
+		Type:      "limit_data",
+		Direction: stream.Downstream,
+		Toxicity:  1,
+	})
+	if link.stubs[len(link.stubs)-1].State == nil {
+		t.Fatalf("New toxic did not have state object created.")
+	}
+}

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -12,13 +12,16 @@ import (
 	"github.com/Shopify/toxiproxy/toxics"
 )
 
+// ToxicCollection contains a list of toxics that are chained together. Each proxy
+// has its own collection. A hidden noop toxic is always maintained at the beginning
+// of each chain so toxics have a method of pausing incoming data (by interrupting
+// the preceding toxic).
 type ToxicCollection struct {
 	sync.Mutex
 
 	noop   *toxics.ToxicWrapper
 	proxy  *Proxy
 	chain  [][]*toxics.ToxicWrapper
-	toxics [][]*toxics.ToxicWrapper
 	links  map[string]*ToxicLink
 }
 
@@ -30,14 +33,11 @@ func NewToxicCollection(proxy *Proxy) *ToxicCollection {
 		},
 		proxy:  proxy,
 		chain:  make([][]*toxics.ToxicWrapper, stream.NumDirections),
-		toxics: make([][]*toxics.ToxicWrapper, stream.NumDirections),
 		links:  make(map[string]*ToxicLink),
 	}
 	for dir := range collection.chain {
 		collection.chain[dir] = make([]*toxics.ToxicWrapper, 1, toxics.Count()+1)
 		collection.chain[dir][0] = collection.noop
-
-		collection.toxics[dir] = make([]*toxics.ToxicWrapper, 0, toxics.Count())
 	}
 	return collection
 }
@@ -46,12 +46,11 @@ func (c *ToxicCollection) ResetToxics() {
 	c.Lock()
 	defer c.Unlock()
 
-	for dir := range c.toxics {
-		for _, toxic := range c.toxics[dir] {
-			// TODO do this in bulk
-			c.chainRemoveToxic(toxic)
+	// Remove all but the first noop toxic
+	for dir := range c.chain {
+		for len(c.chain[dir]) > 1 {
+			c.chainRemoveToxic(c.chain[dir][1])
 		}
-		c.toxics[dir] = c.toxics[dir][:0]
 	}
 }
 
@@ -59,14 +58,7 @@ func (c *ToxicCollection) GetToxic(name string) *toxics.ToxicWrapper {
 	c.Lock()
 	defer c.Unlock()
 
-	for dir := range c.toxics {
-		for _, toxic := range c.toxics[dir] {
-			if toxic.Name == name {
-				return toxic
-			}
-		}
-	}
-	return nil
+	return c.findToxicByName(name)
 }
 
 func (c *ToxicCollection) GetToxicArray() []toxics.Toxic {
@@ -74,8 +66,12 @@ func (c *ToxicCollection) GetToxicArray() []toxics.Toxic {
 	defer c.Unlock()
 
 	result := make([]toxics.Toxic, 0)
-	for dir := range c.toxics {
-		for _, toxic := range c.toxics[dir] {
+	for dir := range c.chain {
+		for i, toxic := range c.chain[dir] {
+			if i == 0 {
+				// Skip the first noop toxic, it should not be visible
+				continue
+			}
 			result = append(result, toxic)
 		}
 	}
@@ -116,12 +112,9 @@ func (c *ToxicCollection) AddToxicJson(data io.Reader) (*toxics.ToxicWrapper, er
 		return nil, ErrInvalidToxicType
 	}
 
-	for dir := range c.toxics {
-		for _, toxic := range c.toxics[dir] {
-			if toxic.Name == wrapper.Name {
-				return nil, ErrToxicAlreadyExists
-			}
-		}
+	found := c.findToxicByName(wrapper.Name)
+	if found != nil {
+		return nil, ErrToxicAlreadyExists
 	}
 
 	// Parse attributes because we now know the toxics type.
@@ -135,7 +128,6 @@ func (c *ToxicCollection) AddToxicJson(data io.Reader) (*toxics.ToxicWrapper, er
 		return nil, joinError(err, ErrBadRequestBody)
 	}
 
-	c.toxics[wrapper.Direction] = append(c.toxics[wrapper.Direction], wrapper)
 	c.chainAddToxic(wrapper)
 	return wrapper, nil
 }
@@ -144,26 +136,23 @@ func (c *ToxicCollection) UpdateToxicJson(name string, data io.Reader) (*toxics.
 	c.Lock()
 	defer c.Unlock()
 
-	for dir := range c.toxics {
-		for _, toxic := range c.toxics[dir] {
-			if toxic.Name == name {
-				attrs := &struct {
-					Attributes interface{} `json:"attributes"`
-					Toxicity   float32     `json:"toxicity"`
-				}{
-					toxic.Toxic,
-					toxic.Toxicity,
-				}
-				err := json.NewDecoder(data).Decode(attrs)
-				if err != nil {
-					return nil, joinError(err, ErrBadRequestBody)
-				}
-				toxic.Toxicity = attrs.Toxicity
-
-				c.chainUpdateToxic(toxic)
-				return toxic, nil
-			}
+	toxic := c.findToxicByName(name)
+	if toxic != nil {
+		attrs := &struct {
+			Attributes interface{} `json:"attributes"`
+			Toxicity   float32     `json:"toxicity"`
+		}{
+			toxic.Toxic,
+			toxic.Toxicity,
 		}
+		err := json.NewDecoder(data).Decode(attrs)
+		if err != nil {
+			return nil, joinError(err, ErrBadRequestBody)
+		}
+		toxic.Toxicity = attrs.Toxicity
+
+		c.chainUpdateToxic(toxic)
+		return toxic, nil
 	}
 	return nil, ErrToxicNotFound
 }
@@ -172,15 +161,10 @@ func (c *ToxicCollection) RemoveToxic(name string) error {
 	c.Lock()
 	defer c.Unlock()
 
-	for dir := range c.toxics {
-		for index, toxic := range c.toxics[dir] {
-			if toxic.Name == name {
-				c.toxics[dir] = append(c.toxics[dir][:index], c.toxics[dir][index+1:]...)
-
-				c.chainRemoveToxic(toxic)
-				return nil
-			}
-		}
+	toxic := c.findToxicByName(name)
+	if toxic != nil {
+		c.chainRemoveToxic(toxic)
+		return nil
 	}
 	return ErrToxicNotFound
 }
@@ -201,6 +185,21 @@ func (c *ToxicCollection) RemoveLink(name string) {
 }
 
 // All following functions assume the lock is already grabbed
+func (c *ToxicCollection) findToxicByName(name string) *toxics.ToxicWrapper {
+	for dir := range c.chain {
+		for i, toxic := range c.chain[dir] {
+			if i == 0 {
+				// Skip the first noop toxic, it has no name
+				continue
+			}
+			if toxic.Name == name {
+				return toxic
+			}
+		}
+	}
+	return nil
+}
+
 func (c *ToxicCollection) chainAddToxic(toxic *toxics.ToxicWrapper) {
 	dir := toxic.Direction
 	toxic.Index = len(c.chain[dir])

--- a/toxics/limit_data.go
+++ b/toxics/limit_data.go
@@ -1,0 +1,50 @@
+package toxics
+
+import "github.com/Shopify/toxiproxy/stream"
+
+// LimitDataToxic has limit in bytes
+type LimitDataToxic struct {
+	Bytes            int64 `json:"bytes"`
+	bytesTransmitted int64
+}
+
+func (t *LimitDataToxic) Pipe(stub *ToxicStub) {
+	var bytesRemaining = t.Bytes - t.bytesTransmitted
+
+	for {
+		select {
+		case <-stub.Interrupt:
+			return
+		case c := <-stub.Input:
+			if c == nil {
+				stub.Close()
+				return
+			}
+
+			chunk := c
+
+			if bytesRemaining < int64(len(c.Data)) {
+				chunk = &stream.StreamChunk{
+					Timestamp: c.Timestamp,
+					Data:      c.Data[0:bytesRemaining],
+				}
+			}
+
+			if len(chunk.Data) > 0 {
+				stub.Output <- chunk
+				t.bytesTransmitted += int64(len(chunk.Data))
+			}
+
+			bytesRemaining = t.Bytes - t.bytesTransmitted
+
+			if bytesRemaining <= 0 {
+				stub.Close()
+				return
+			}
+		}
+	}
+}
+
+func init() {
+	Register("limit_data", new(LimitDataToxic))
+}

--- a/toxics/limit_data_test.go
+++ b/toxics/limit_data_test.go
@@ -2,8 +2,8 @@ package toxics_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/Shopify/toxiproxy/stream"
@@ -34,6 +34,7 @@ func check(t *testing.T, toxic *toxics.LimitDataToxic, chunks [][]byte, expected
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk, 100)
 	stub := toxics.NewToxicStub(input, output)
+	stub.State = toxic.NewState()
 
 	go toxic.Pipe(stub)
 
@@ -48,12 +49,13 @@ func check(t *testing.T, toxic *toxics.LimitDataToxic, chunks [][]byte, expected
 	checkRemainingChunks(t, output)
 }
 
-func TestLimitDataToxicMayBeInterrupted(t *testing.T) {
+func TestLimitDataToxicMayBeRestarted(t *testing.T) {
 	toxic := &toxics.LimitDataToxic{Bytes: 100}
 
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk, 100)
 	stub := toxics.NewToxicStub(input, output)
+	stub.State = toxic.NewState()
 
 	buf := buffer(90)
 	buf2 := buffer(20)
@@ -78,12 +80,13 @@ func TestLimitDataToxicMayBeInterrupted(t *testing.T) {
 	checkRemainingChunks(t, output)
 }
 
-func TestLimitDataToxicMayBeRestarted(t *testing.T) {
+func TestLimitDataToxicMayBeInterrupted(t *testing.T) {
 	toxic := &toxics.LimitDataToxic{Bytes: 100}
 
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk)
 	stub := toxics.NewToxicStub(input, output)
+	stub.State = toxic.NewState()
 
 	go func() {
 		stub.Interrupt <- struct{}{}
@@ -98,6 +101,7 @@ func TestLimitDataToxicNilShouldClosePipe(t *testing.T) {
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk)
 	stub := toxics.NewToxicStub(input, output)
+	stub.State = toxic.NewState()
 
 	go func() {
 		input <- nil

--- a/toxics/limit_data_test.go
+++ b/toxics/limit_data_test.go
@@ -1,0 +1,156 @@
+package toxics_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/Shopify/toxiproxy/stream"
+	"github.com/Shopify/toxiproxy/toxics"
+)
+
+func buffer(size int) []byte {
+	buf := make([]byte, size)
+	rand.Read(buf)
+
+	return buf
+}
+
+func checkOutgoingChunk(t *testing.T, output chan *stream.StreamChunk, expected []byte) {
+	chunk := <-output
+	if !bytes.Equal(chunk.Data, expected) {
+		t.Error("Data in outgoing chunk doesn't match expected values")
+	}
+}
+
+func checkRemainingChunks(t *testing.T, output chan *stream.StreamChunk) {
+	if len(output) != 0 {
+		t.Error(fmt.Sprintf("There is %d chunks in output channel. 0 is expected.", len(output)))
+	}
+}
+
+func check(t *testing.T, toxic *toxics.LimitDataToxic, chunks [][]byte, expectedChunks [][]byte) {
+	input := make(chan *stream.StreamChunk)
+	output := make(chan *stream.StreamChunk, 100)
+	stub := toxics.NewToxicStub(input, output)
+
+	go toxic.Pipe(stub)
+
+	for _, buf := range chunks {
+		input <- &stream.StreamChunk{Data: buf}
+	}
+
+	for _, expected := range expectedChunks {
+		checkOutgoingChunk(t, output, expected)
+	}
+
+	checkRemainingChunks(t, output)
+}
+
+func TestLimitDataToxicMayBeInterrupted(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	input := make(chan *stream.StreamChunk)
+	output := make(chan *stream.StreamChunk, 100)
+	stub := toxics.NewToxicStub(input, output)
+
+	buf := buffer(90)
+	buf2 := buffer(20)
+
+	// Send chunk with data not exceeding limit and interrupt
+	go func() {
+		input <- &stream.StreamChunk{Data: buf}
+		stub.Interrupt <- struct{}{}
+	}()
+
+	toxic.Pipe(stub)
+	checkOutgoingChunk(t, output, buf)
+
+	// Send 2nd chunk to exceed limit
+	go func() {
+		input <- &stream.StreamChunk{Data: buf2}
+	}()
+
+	toxic.Pipe(stub)
+	checkOutgoingChunk(t, output, buf2[0:10])
+
+	checkRemainingChunks(t, output)
+}
+
+func TestLimitDataToxicMayBeRestarted(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	input := make(chan *stream.StreamChunk)
+	output := make(chan *stream.StreamChunk)
+	stub := toxics.NewToxicStub(input, output)
+
+	go func() {
+		stub.Interrupt <- struct{}{}
+	}()
+
+	toxic.Pipe(stub)
+}
+
+func TestLimitDataToxicNilShouldClosePipe(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	input := make(chan *stream.StreamChunk)
+	output := make(chan *stream.StreamChunk)
+	stub := toxics.NewToxicStub(input, output)
+
+	go func() {
+		input <- nil
+	}()
+
+	toxic.Pipe(stub)
+}
+
+func TestLimitDataToxicChunkSmallerThanLimit(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	buf := buffer(50)
+	check(t, toxic, [][]byte{buf}, [][]byte{buf})
+}
+
+func TestLimitDataToxicChunkLengthMatchesLimit(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	buf := buffer(100)
+	check(t, toxic, [][]byte{buf}, [][]byte{buf})
+}
+
+func TestLimitDataToxicChunkBiggerThanLimit(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	buf := buffer(150)
+	expected := buf[0:100]
+
+	check(t, toxic, [][]byte{buf}, [][]byte{expected})
+}
+
+func TestLimitDataToxicMultipleChunksMatchThanLimit(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	buf := buffer(25)
+
+	check(t, toxic, [][]byte{buf, buf, buf, buf}, [][]byte{buf, buf, buf, buf})
+}
+
+func TestLimitDataToxicSecondChunkWouldOverflowLimit(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 100}
+
+	buf := buffer(90)
+	buf2 := buffer(20)
+	expected := buf2[0:10]
+
+	check(t, toxic, [][]byte{buf, buf2}, [][]byte{buf, expected})
+}
+
+func TestLimitDataToxicLimitIsSetToZero(t *testing.T) {
+	toxic := &toxics.LimitDataToxic{Bytes: 0}
+
+	buf := buffer(100)
+
+	check(t, toxic, [][]byte{buf}, [][]byte{})
+}

--- a/toxics/limit_data_test.go
+++ b/toxics/limit_data_test.go
@@ -2,8 +2,8 @@ package toxics_test
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/Shopify/toxiproxy/stream"

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -31,6 +31,14 @@ type BufferedToxic interface {
 	GetBufferSize() int
 }
 
+// Stateful toxics store a per-connection state object on the ToxicStub.
+// The state is created once when the toxic is added and persists until the
+// toxic is removed or the connection is closed.
+type StatefulToxic interface {
+	// Creates a new object to store toxic state in
+	NewState() interface{}
+}
+
 type ToxicWrapper struct {
 	Toxic      `json:"attributes"`
 	Name       string           `json:"name"`
@@ -45,6 +53,7 @@ type ToxicWrapper struct {
 type ToxicStub struct {
 	Input     <-chan *stream.StreamChunk
 	Output    chan<- *stream.StreamChunk
+	State     interface{}
 	Interrupt chan struct{}
 	running   chan struct{}
 	closed    chan struct{}


### PR DESCRIPTION
Adds https://github.com/Shopify/toxiproxy/pull/125 with some fixes
I made some simplifications to `toxic_collection.go` that don't change anything other than make the code look nicer (no more duplicated `c.chain` and `c.toxics`)

Stateful toxics are added to allow for per-connection toxic state to be stored.
This fixes the issue of `bytesTransmitted` in the limit_data toxic being shared between connections.

@Sirupsen @pushrax 
cc @matez 