### PR TITLE
Change cli to allow remote toxiproxy hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.1.0 (Unreleased)
 
-* Add support for stateful toxics
+* Allow hostname to be specified in CLI #129
+* Add support for stateful toxics #127
 * Add limit_data toxic
 
 # 2.0.0


### PR DESCRIPTION
Adds `--host / -h` to specify the toxiproxy host to connect to.

For https://github.com/Shopify/toxiproxy/issues/128

@Sirupsen 
cc @dylanahsmith 