### PR TITLE
Scriptable CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.1.0 (Unreleased)
 
+* Updated CLI for scriptability #133
 * Add `/populate` endpoint to server #111
 * Change error responses from `title` to `error`
 * Allow hostname to be specified in CLI #129

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,30 +14,19 @@ import (
 )
 
 const (
-	RED = iota
-	GREEN
-	YELLOW
-	BLUE
-	CYAN
-	PURPLE
-	GRAY
-	NONE
+	RED    = "\x1b[31m"
+	GREEN  = "\x1b[32m"
+	YELLOW = "\x1b[33m"
+	BLUE   = "\x1b[34m"
+	CYAN   = "\x1b[36m"
+	PURPLE = "\x1b[35m"
+	GRAY   = "\x1b[37m"
+	NONE   = "\x1b[0m"
 )
 
-var colors = map[int]string{
-	RED:    "\x1b[31m",
-	GREEN:  "\x1b[32m",
-	YELLOW: "\x1b[33m",
-	BLUE:   "\x1b[34m",
-	CYAN:   "\x1b[36m",
-	PURPLE: "\x1b[35m",
-	GRAY:   "\x1b[37m",
-	NONE:   "\x1b[0m",
-}
-
-func color(color int) string {
+func color(color string) string {
 	if isTTY {
-		return colors[color]
+		return color
 	} else {
 		return ""
 	}
@@ -260,11 +249,7 @@ func list(c *cli.Context, t *toxiproxy.Client) error {
 		if numToxics == "0" && isTTY {
 			numToxics = "None"
 		}
-		if proxy.Enabled {
-			printWidth(GREEN, proxy.Name, 3)
-		} else {
-			printWidth(RED, proxy.Name, 3)
-		}
+		printWidth(color(colorEnabled(proxy.Enabled)), proxy.Name, 3)
 		printWidth(BLUE, proxy.Listen, 2)
 		printWidth(YELLOW, proxy.Upstream, 3)
 		printWidth(PURPLE, enabledText(proxy.Enabled), 2)
@@ -605,14 +590,14 @@ func errorf(m string, args ...interface{}) error {
 	return cli.NewExitError(fmt.Sprintf(m, args...), 1)
 }
 
-func printWidth(col int, m string, numTabs int) {
-	if !isTTY {
-		numTabs = 0
-	} else {
+func printWidth(col string, m string, numTabs int) {
+	if isTTY {
 		numTabs -= len(m)/8 + 1
 		if numTabs < 0 {
 			numTabs = 0
 		}
+	} else {
+		numTabs = 0
 	}
 	fmt.Printf("%s%s%s\t%s", color(col), m, color(NONE), strings.Repeat("\t", numTabs))
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -51,13 +51,13 @@ var toxicDescription = `
 
 	toxic add:
 		usage: toxiproxy-cli add <proxyName> --type <toxicType> --toxicName <toxicName> \
-		--attributes <key1=value1,key2=value2...> --upstream --downstream
+		--attribute <key=value> --upstream --downstream
 
 		example: toxiproxy-cli toxic add myProxy -t latency -n myToxic -f latency=100,jitter=50
 
 	toxic update:
 		usage: toxiproxy-cli update <proxyName> --toxicName <toxicName> \
-		--attributes <key1=value1,key2=value2...>
+		--attribute <key1=value1> --attribute <key2=value2>
 
 		example: toxiproxy-cli toxic update myProxy -n myToxic -f jitter=25
 
@@ -141,8 +141,8 @@ func main() {
 							Usage: "toxicity of toxic",
 						},
 						cli.StringSliceFlag{
-							Name:  "attributes, a",
-							Usage: "comma seperated key=value toxic attributes",
+							Name:  "attribute, a",
+							Usage: "toxic attribute in key=value format",
 						},
 						cli.BoolFlag{
 							Name:  "upstream, u",
@@ -170,8 +170,8 @@ func main() {
 							Usage: "toxicity of toxic",
 						},
 						cli.StringSliceFlag{
-							Name:  "attributes, a",
-							Usage: "comma seperated key=value toxic attributes",
+							Name:  "attribute, a",
+							Usage: "toxic attribute in key=value format",
 						},
 					},
 					Action: withToxi(updateToxic),
@@ -403,7 +403,7 @@ func addToxic(c *cli.Context, t *toxiproxy.Client) error {
 		return err
 	}
 
-	attributes := parseAttributes(c, "attributes")
+	attributes := parseAttributes(c, "attribute")
 
 	p, err := t.Proxy(proxyName)
 	if err != nil {
@@ -444,7 +444,7 @@ func updateToxic(c *cli.Context, t *toxiproxy.Client) error {
 		return err
 	}
 
-	attributes := parseAttributes(c, "attributes")
+	attributes := parseAttributes(c, "attribute")
 
 	p, err := t.Proxy(proxyName)
 	if err != nil {


### PR DESCRIPTION
The cli has proven itself to be very useful for quickly testing things, but until now it hasn't been very useful as part of scripts and automation.
This PR adds some checks to see if a real TTY is being used, and changes the output format if the cli is used as part of a pipe:

## Example:
```
∙ ./toxiproxy-cli list
Name   			Listen 		Upstream       		Enabled		Toxics
======================================================================================
4      			[::]:8083      	google.com:80  		enabled		None
google 			[::]:8080      	google.com:80  		enabled		3
google2			[::]:8081      	google.com:80  		enabled		None
google3longggggg       	[::]:8082      	google.com:80  		enabled		None

Hint: inspect toxics with `toxiproxy-cli inspect <proxyName>`

∙ ./toxiproxy-cli list | cat
4      	[::]:8083      	google.com:80  	enabled	0
google 	[::]:8080      	google.com:80  	enabled	3
google2	[::]:8081      	google.com:80  	enabled	0
google3longggggg       	[::]:8082      	google.com:80  	enabled	0
```

This allows for some interesting usage from bash:
```
∙ ./toxiproxy-cli ls | cut -f 1 | xargs -n1 ./toxiproxy-cli toggle
Proxy 4 is now disabled
Proxy google is now disabled
Proxy google2 is now disabled
Proxy google3longggggg is now disabled

∙ ./toxiproxy-cli i google | grep upstream | cut -f 1 | xargs -n1 ./toxiproxy-cli toxic update google -tox 0.5 -n
Updated toxic 'latency_upstream' on proxy 'google'
Updated toxic 'bandwidth_upstream' on proxy 'google'
```

## Other Changes
While writing this I noticed some problems with how toxic attributes were parsed (mainly only supporting integer values), so I've updated that as well to the following format:
`./toxiproxy-cli toxic create google -t latency -a latency=500 -a jitter=10`

This format supports integers, floats, and string fields.

This PR also updates the cli to use the new error handling api: https://github.com/Shopify/toxiproxy/issues/113

@Sirupsen @pushrax @jpittis 