### PR TITLE
Mention global toxic attributes in toxics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,19 @@ Please consult your respective client library on usage.
 ### Toxics
 
 Toxics manipulate the pipe between the client and upstream. They can be added
-and removed from proxies using the [HTTP api](#http-api). Each toxic has its own parameters
-to change how it affects the proxy links.
+and removed from proxies using the [HTTP api](#http-api).
 
 For documentation on implementing custom toxics, see [CREATING_TOXICS.md](https://github.com/Shopify/toxiproxy/blob/master/CREATING_TOXICS.md)
+
+Every Toxic has the following parameters:
+
+ - `name`: toxic name (string, defaults to `<type>_<stream>`)
+ - `type`: toxic type (string)
+ - `stream`: link direction to affect (defaults to downstream)
+ - `toxicity`: probability of the toxic being applied to a link (defaults to 1.0, 100%).  This
+   is evaluated for every newly created connection and remains in effect for the lifetime of the connection..
+
+Each toxic also has its own attributes, documented below.
 
 #### latency
 


### PR DESCRIPTION
global toxic attributes were only defined in
'HTTP API' -> 'Toxic fields'. We should also mention them in the
Toxics section itself.
In particular the `toxicity` setting needs a clear explanation since
it's easy to have the wrong assumptions about how it works
(e.g. I thought it would control the application of the toxic on a more
fine-grained level within each connection:
https://github.com/Shopify/toxiproxy/issues/139#issuecomment-255374755
)
