### PR TITLE
build a leaner toxiproxy container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM golang:1.7
+FROM alpine
 
-COPY . /go/src/github.com/Shopify/toxiproxy
-
-RUN go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat /go/src/github.com/Shopify/toxiproxy/VERSION)" -o /go/bin/toxiproxy github.com/Shopify/toxiproxy/cmd && \
-    go build -o /go/bin/toxiproxy-cli github.com/Shopify/toxiproxy/cli
+COPY tmp/toxiproxy /go/bin/toxiproxy
+COPY tmp/toxiproxy-cli /go/bin/toxiproxy-cli
 
 EXPOSE 8474
 ENTRYPOINT ["/go/bin/toxiproxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
-COPY tmp/toxiproxy /go/bin/toxiproxy
-COPY tmp/toxiproxy-cli /go/bin/toxiproxy-cli
+COPY tmp/build/toxiproxy-server-linux-amd64 /go/bin/toxiproxy
+COPY tmp/build/toxiproxy-cli-linux-amd64 /go/bin/toxiproxy-cli
 
 EXPOSE 8474
 ENTRYPOINT ["/go/bin/toxiproxy"]

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,9 @@ docker:
 	docker build --tag="shopify/toxiproxy:git" .
 
 docker-release:
-	docker build --tag="shopify/toxiproxy:$(VERSION)" .
+	mkdir -p tmp
+	docker run -it --rm -v `pwd`/tmp:/go/bin -v `pwd`:/go/src/github.com/Shopify/toxiproxy golang:1.7 sh -c 'go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat /go/src/github.com/Shopify/toxiproxy/VERSION)" -o /go/bin/toxiproxy github.com/Shopify/toxiproxy/cmd && go build -o /go/bin/toxiproxy-cli github.com/Shopify/toxiproxy/cli'
+	docker build --rm=true --tag="shopify/toxiproxy:$(VERSION)" .
 	docker tag shopify/toxiproxy:$(VERSION) shopify/toxiproxy:latest
 	docker push shopify/toxiproxy:$(VERSION)
 	docker push shopify/toxiproxy:latest

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,7 @@ $(DEB): tmp/build/$(SERVER_NAME)-linux-amd64 tmp/build/$(CLI_NAME)-linux-amd64
 docker:
 	docker build --tag="shopify/toxiproxy:git" .
 
-docker-release:
-	mkdir -p tmp
-	docker run -it --rm -v `pwd`/tmp:/go/bin -v `pwd`:/go/src/github.com/Shopify/toxiproxy golang:1.7 sh -c 'go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat /go/src/github.com/Shopify/toxiproxy/VERSION)" -o /go/bin/toxiproxy github.com/Shopify/toxiproxy/cmd && go build -o /go/bin/toxiproxy-cli github.com/Shopify/toxiproxy/cli'
+docker-release: linux
 	docker build --rm=true --tag="shopify/toxiproxy:$(VERSION)" .
 	docker tag shopify/toxiproxy:$(VERSION) shopify/toxiproxy:latest
 	docker push shopify/toxiproxy:$(VERSION)

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: toxiproxy
 
 up:
-  - go: 1.6.2
+  - go: 1.7.3
 
 commands:
   build:


### PR DESCRIPTION
This builds a leaner container for toxiproxy. 

Originally we were building the toxiproxy container and including the entire golang runtime in the container.

```
shiv@Shiv-Mac toxiproxy (master) $ docker build --tag="shopify/toxiproxy:2.0.0" .
Sending build context to Docker daemon 17.34 MB
Step 1/6 : FROM golang:1.7
 ---> ef15416724f6
Step 2/6 : COPY . /go/src/github.com/Shopify/toxiproxy
 ---> 52f7c3acd605
Removing intermediate container 1cd1617aa433
Step 3/6 : RUN go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat /go/src/github.com/Shopify/toxiproxy/VERSION)" -o /go/bin/toxiproxy github.com/Shopify/toxiproxy/cmd &&     go build -o /go/bin/toxiproxy-cli github.com/Shopify/toxiproxy/cli
 ---> Running in 8b028157f1f8
 ---> b60805b8fd09
Removing intermediate container 8b028157f1f8
Step 4/6 : EXPOSE 8474
 ---> Running in 29bcd32afb9c
 ---> 702edfbc81dc
Removing intermediate container 29bcd32afb9c
Step 5/6 : ENTRYPOINT /go/bin/toxiproxy
 ---> Running in 8adbfe8173dc
 ---> dd5f105904ef
Removing intermediate container 8adbfe8173dc
Step 6/6 : CMD -host=0.0.0.0
 ---> Running in 8731c95b0012
 ---> b4c7a6c266de
Removing intermediate container 8731c95b0012
Successfully built b4c7a6c266de
shiv@Shiv-Mac toxiproxy (master) $ docker images | grep toxipro
shopify/toxiproxy                         2.0.0               b4c7a6c266de        18 seconds ago      704 MB
shiv@Shiv-Mac toxiproxy (master) $
```

With the new changes, we build the necessary toxiproxy binaries, inside the same golang Vm as above, but then build a distributable container using a lean alpine image, including just the binaries.

```
shiv@Shiv-Mac toxiproxy (toxiproxy_small_container) $ docker run -it --rm -v `pwd`/tmp:/go/bin -v `pwd`:/go/src/github.com/Shopify/toxiproxy golang:1.7 sh -c 'go build -ldflags="-X github.com/Shopify/toxiproxy.Version=$(cat /go/src/github.com/Shopify/toxiproxy/VERSION)" -o /go/bin/toxiproxy github.com/Shopify/toxiproxy/cmd && go build -o /go/bin/toxiproxy-cli github.com/Shopify/toxiproxy/cli'
shiv@Shiv-Mac toxiproxy (toxiproxy_small_container) $ docker build --rm=true --tag="shopify/toxiproxy_shiv:2.0.0" .
Sending build context to Docker daemon 17.34 MB
Step 1/6 : FROM alpine
 ---> 7d23b3ca3463
Step 2/6 : COPY tmp/toxiproxy /go/bin/toxiproxy
 ---> 890ac4d251b2
Removing intermediate container 8a6ed8349f3d
Step 3/6 : COPY tmp/toxiproxy-cli /go/bin/toxiproxy-cli
 ---> 36283dd1283e
Removing intermediate container 0fd110b26219
Step 4/6 : EXPOSE 8474
 ---> Running in 0983e2f21f7d
 ---> 5d2a7fcca6a8
Removing intermediate container 0983e2f21f7d
Step 5/6 : ENTRYPOINT /go/bin/toxiproxy
 ---> Running in ff75cb8ee45b
 ---> 15e544ef55a4
Removing intermediate container ff75cb8ee45b
Step 6/6 : CMD -host=0.0.0.0
 ---> Running in 15499a1b88ae
 ---> cedf52aefc54
Removing intermediate container 15499a1b88ae
Successfully built cedf52aefc54
🦄  you can run dev up to install everything you need to run this project.
shiv@Shiv-Mac toxiproxy (toxiproxy_small_container) $ docker images | grep toxi
shopify/toxiproxy_shiv                    2.0.0               cedf52aefc54        7 seconds ago       18.9 MB
shopify/toxiproxy                         2.0.0               b4c7a6c266de        2 minutes ago       704 MB
shiv@Shiv-Mac toxiproxy (toxiproxy_small_container) $
```

This will help things like `nginx-routing-modules`, that pull this container, since we have reduced the size from `704MB` to `18.9MB`
This is similar to https://github.com/Shopify/magellan/pull/94