### PR TITLE
Adding static configuration to toxi proxy

### DIFF
--- a/api.go
+++ b/api.go
@@ -46,6 +46,9 @@ func (server *ApiServer) Listen(host string, port string) {
 		"version": Version,
 	}).Info("API HTTP server starting")
 
+
+
+
 	err := http.ListenAndServe(net.JoinHostPort(host, port), nil)
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)

--- a/cmd/toxiproxy.go
+++ b/cmd/toxiproxy.go
@@ -6,10 +6,24 @@ import (
 	"time"
 
 	"github.com/Shopify/toxiproxy"
+
+	"io/ioutil"
+	"github.com/Sirupsen/logrus"
+	"encoding/json"
 )
 
 var host string
 var port string
+
+type ProxyConfig struct {
+	Name string
+	Host   string
+	Listen string
+}
+
+type ProxyConfigs struct {
+	Service [] ProxyConfig
+}
 
 func init() {
 	flag.StringVar(&host, "host", "localhost", "Host for toxiproxy's API to listen on")
@@ -21,5 +35,28 @@ func init() {
 
 func main() {
 	server := toxiproxy.NewServer()
+	addPreConfiguredProxies(server)
 	server.Listen(host, port)
+}
+
+func addPreConfiguredProxies(server *toxiproxy.ApiServer)  {
+	file, e := ioutil.ReadFile("config.json")
+	if e != nil {
+		logrus.Info("Error reading config file, carry on without.\n", e)
+		return
+	}
+	logrus.Info("Got proxies config:\n", string(file))
+
+	var proxyConfigs ProxyConfigs
+
+	json.Unmarshal(file, &proxyConfigs)
+
+	for _, s := range proxyConfigs.Service {
+		logrus.Debug("Adding proxy for upstream %s to listten on \n", s.Host, s.Listen)
+		newProxy := toxiproxy.NewProxy();
+		newProxy.Name = s.Name
+		newProxy.Upstream = s.Host
+		newProxy.Listen = s.Listen
+		server.Collection.Add(newProxy, true)
+	}
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "service": [
+    {
+      "name": "sm",
+      "host": "localhost:8989",
+      "listen": "localhost:9878"
+    }
+  ]
+}

--- a/proxy.go
+++ b/proxy.go
@@ -59,7 +59,6 @@ func NewProxy() *Proxy {
 func (proxy *Proxy) Start() error {
 	proxy.Lock()
 	defer proxy.Unlock()
-
 	return start(proxy)
 }
 

--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -2,6 +2,8 @@ package toxiproxy
 
 import "sync"
 
+
+
 // ProxyCollection is a collection of proxies. It's the interface for anything
 // to add and remove proxies from the toxiproxy instance. It's responsibilty is
 // to maintain the integrity of the proxy set, by guarding for things such as
@@ -12,9 +14,14 @@ type ProxyCollection struct {
 	proxies map[string]*Proxy
 }
 
+
+
+
 func NewProxyCollection() *ProxyCollection {
+
+
 	return &ProxyCollection{
-		proxies: make(map[string]*Proxy),
+		proxies : make(map[string]*Proxy),
 	}
 }
 


### PR DESCRIPTION
Currently the proxies are volatile and their config vanishes after restart. In our environment we need to be able to specify a few upstream service endpoints that never change and have to be available from toxiproxy startup.

The purpose of this request is to add static proxies configuration as seen in config.json. Sorry about empty lines in api.go and proxy_collection.go

THIS SOFTWARE CONTRIBUTION IS PROVIDED ON BEHALF OF SKY PLC. BY THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED
