### PR TITLE
Add -config option for toxiproxy startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.1.0 (Unreleased)
 
+* Add -config server option to populate on startup #154
 * Updated CLI for scriptability #133
 * Add `/populate` endpoint to server #111
 * Change error responses from `title` to `error`

--- a/README.md
+++ b/README.md
@@ -280,7 +280,9 @@ This makes sure there are no clashes between applications using the same
 Toxiproxy.
 
 For large application we recommend storing the Toxiproxy configurations in a
-separate configuration file. We use `config/toxiproxy.json`.
+separate configuration file. We use `config/toxiproxy.json`. This file can be
+passed to the server using the `-config` option, or loaded by the application
+to use with the `populate` function.
 
 Use ports outside the ephemeral port range to avoid random port conflicts.
 It's `32,768` to `61,000` on Linux by default, see

--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/Shopify/toxiproxy/toxics"
 	"github.com/Sirupsen/logrus"
@@ -19,6 +20,29 @@ type ApiServer struct {
 func NewServer() *ApiServer {
 	return &ApiServer{
 		Collection: NewProxyCollection(),
+	}
+}
+
+func (server *ApiServer) PopulateConfig(filename string) {
+	file, err := os.Open(filename)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"config": filename,
+			"error":  err,
+		}).Error("Error reading config file")
+	} else {
+		proxies, err := server.Collection.PopulateJson(file)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"config": filename,
+				"error":  err,
+			}).Error("Failed to populate proxies from file")
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"config":  filename,
+				"proxies": len(proxies),
+			}).Info("Populated proxies from file")
+		}
 	}
 }
 

--- a/cmd/toxiproxy.go
+++ b/cmd/toxiproxy.go
@@ -3,11 +3,9 @@ package main
 import (
 	"flag"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/Shopify/toxiproxy"
-	"github.com/Sirupsen/logrus"
 )
 
 var host string
@@ -26,26 +24,7 @@ func init() {
 func main() {
 	server := toxiproxy.NewServer()
 	if len(config) > 0 {
-		file, err := os.Open(config)
-		if err != nil {
-			logrus.WithFields(logrus.Fields{
-				"config": config,
-				"error":  err,
-			}).Error("Error reading config file")
-		} else {
-			proxies, err := server.Collection.PopulateJson(file)
-			if err != nil {
-				logrus.WithFields(logrus.Fields{
-					"config": config,
-					"error":  err,
-				}).Error("Failed to populate proxies from file")
-			} else {
-				logrus.WithFields(logrus.Fields{
-					"config":  config,
-					"proxies": len(proxies),
-				}).Info("Populated proxies from file")
-			}
-		}
+		server.PopulateConfig(config)
 	}
 	server.Listen(host, port)
 }

--- a/cmd/toxiproxy.go
+++ b/cmd/toxiproxy.go
@@ -3,17 +3,21 @@ package main
 import (
 	"flag"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/Shopify/toxiproxy"
+	"github.com/Sirupsen/logrus"
 )
 
 var host string
 var port string
+var config string
 
 func init() {
 	flag.StringVar(&host, "host", "localhost", "Host for toxiproxy's API to listen on")
 	flag.StringVar(&port, "port", "8474", "Port for toxiproxy's API to listen on")
+	flag.StringVar(&config, "config", "", "JSON file containing proxies to create on startup")
 	seed := flag.Int64("seed", time.Now().UTC().UnixNano(), "Seed for randomizing toxics with")
 	flag.Parse()
 	rand.Seed(*seed)
@@ -21,5 +25,27 @@ func init() {
 
 func main() {
 	server := toxiproxy.NewServer()
+	if len(config) > 0 {
+		file, err := os.Open(config)
+		if err != nil {
+			logrus.WithFields(logrus.Fields{
+				"config": config,
+				"error":  err,
+			}).Error("Error reading config file")
+		} else {
+			proxies, err := server.Collection.PopulateJson(file)
+			if err != nil {
+				logrus.WithFields(logrus.Fields{
+					"config": config,
+					"error":  err,
+				}).Error("Failed to populate proxies from file")
+			} else {
+				logrus.WithFields(logrus.Fields{
+					"config":  config,
+					"proxies": len(proxies),
+				}).Info("Populated proxies from file")
+			}
+		}
+	}
 	server.Listen(host, port)
 }

--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -1,6 +1,11 @@
 package toxiproxy
 
-import "sync"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
 
 // ProxyCollection is a collection of proxies. It's the interface for anything
 // to add and remove proxies from the toxiproxy instance. It's responsibilty is
@@ -59,6 +64,49 @@ func (collection *ProxyCollection) AddOrReplace(proxy *Proxy, start bool) error 
 	collection.proxies[proxy.Name] = proxy
 
 	return nil
+}
+
+func (collection *ProxyCollection) PopulateJson(data io.Reader) ([]*Proxy, error) {
+	input := []struct {
+		Proxy
+		Enabled *bool `json:"enabled"` // Overrides Proxy field to make field nullable
+	}{}
+
+	err := json.NewDecoder(data).Decode(&input)
+	if err != nil {
+		return nil, joinError(err, ErrBadRequestBody)
+	}
+
+	// Check for valid input before creating any proxies
+	t := true
+	for i, p := range input {
+		if len(p.Name) < 1 {
+			return nil, joinError(fmt.Errorf("name at proxy %d", i+1), ErrMissingField)
+		}
+		if len(p.Upstream) < 1 {
+			return nil, joinError(fmt.Errorf("upstream at proxy %d", i+1), ErrMissingField)
+		}
+		if p.Enabled == nil {
+			input[i].Enabled = &t
+		}
+	}
+
+	proxies := make([]*Proxy, 0, len(input))
+
+	for _, p := range input {
+		proxy := NewProxy()
+		proxy.Name = p.Name
+		proxy.Listen = p.Listen
+		proxy.Upstream = p.Upstream
+
+		err = collection.AddOrReplace(proxy, *p.Enabled)
+		if err != nil {
+			break
+		}
+
+		proxies = append(proxies, proxy)
+	}
+	return proxies, err
 }
 
 func (collection *ProxyCollection) Proxies() map[string]*Proxy {


### PR DESCRIPTION
I'd like to get a 2.1.0 released soon, since there's a lot of unreleased features piling up.
I put together the functionality described in https://github.com/Shopify/toxiproxy/pull/153 in this PR so we can get it included in 2.1.0

Example:
```
[
  {
    "name": "redis",
    "upstream": "localhost:6379",
    "listen": "localhost:6380"
  }
]
```

```
$ ./toxiproxy-server -config test.json
INFO[0000] Started proxy                                 name=redis proxy=127.0.0.1:6380 upstream=localhost:6379
INFO[0000] Populated proxies from file                   config=test.json proxies=1
INFO[0000] API HTTP server starting                      host=localhost port=8474 version=git-8e40aad
INFO[0002] Accepted client                               client=127.0.0.1:57170 name=redis proxy=127.0.0.1:6380 upstream=localhost:6379
```

```
$ redis-cli -p 6380
127.0.0.1:6380> SET foo bar
OK
127.0.0.1:6380> GET foo
"bar"
```

@sirupsen @delta-bravo