### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Toxiproxy
+[![GitHub release](https://img.shields.io/github/release/Shopify/toxiproxy.svg)](https://github.com/Shopify/toxiproxy/releases/latest)
+[![Build Status](https://img.shields.io/circleci/project/github/Shopify/toxiproxy/master.svg)](https://circleci.com/gh/Shopify/toxiproxy/tree/master)
+[![IRC Channel](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](https://kiwiirc.com/client/irc.freenode.net/#toxiproxy)
 
 ![](http://i.imgur.com/sOaNw0o.png)
 
@@ -220,6 +223,8 @@ Toxiproxy is available on [Docker Hub](https://hub.docker.com/r/shopify/toxiprox
 $ docker pull shopify/toxiproxy
 $ docker run -it shopify/toxiproxy
 ```
+
+If using Toxiproxy from the host rather than other containers, enable host networking with `--net=host`.
 
 **Source**
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -53,7 +53,7 @@ var toxicDescription = `
 		usage: toxiproxy-cli add <proxyName> --type <toxicType> --toxicName <toxicName> \
 		--attribute <key=value> --upstream --downstream
 
-		example: toxiproxy-cli toxic add myProxy -t latency -n myToxic -a latency=100,jitter=50
+		example: toxiproxy-cli toxic add myProxy -t latency -n myToxic -a latency=100 -a jitter=50
 
 	toxic update:
 		usage: toxiproxy-cli update <proxyName> --toxicName <toxicName> \


### PR DESCRIPTION
This adds some badges to the README and addresses a few issues that were mentioned with the docs.

1. Mention `--net=host` for docker port forwarding: https://github.com/Shopify/toxiproxy/issues/151
2. Add a link to the freenode irc channel as a badge: https://github.com/Shopify/toxiproxy/issues/147
3. Fix incorrect cli doc for specifying multiple toxic attributes: https://github.com/Shopify/toxiproxy/issues/139

@sirupsen @jpittis 