### PR TITLE
Revert "readme: add recommending 2.0.0 until issue is fixed"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 
 ![](http://i.imgur.com/sOaNw0o.png)
 
-**NOTE**: Until https://github.com/Shopify/toxiproxy/issues/159 is fixed in
-`2.1.1` we recommend using the `2.0.0` release.
-
 Toxiproxy is a framework for simulating network conditions. It's made
 specifically to work in testing, CI and development environments, supporting
 deterministic tampering with connections, but with support for randomized chaos
@@ -201,9 +198,6 @@ binaries and system packages for your architecture.
 
 **Ubuntu**
 
-**NOTE**: Until https://github.com/Shopify/toxiproxy/issues/159 is fixed in
-`2.1.1` we recommend using the `2.0.0` release.
-
 ```bash
 $ wget -O toxiproxy-2.1.0.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.0/toxiproxy_2.1.0_amd64.deb
 $ sudo dpkg -i toxiproxy-2.1.0.deb
@@ -212,9 +206,6 @@ $ sudo service toxiproxy start
 
 **OS X**
 
-**NOTE**: Until https://github.com/Shopify/toxiproxy/issues/159 is fixed in
-`2.1.1` we recommend using the `2.0.0` release.
-
 ```bash
 $ brew tap shopify/shopify
 $ brew install toxiproxy
@@ -222,15 +213,9 @@ $ brew install toxiproxy
 
 **Windows**
 
-**NOTE**: Until https://github.com/Shopify/toxiproxy/issues/159 is fixed in
-`2.1.1` we recommend using the `2.0.0` release.
-
 Toxiproxy for Windows is available for download at https://github.com/Shopify/toxiproxy/releases/download/v2.1.0/toxiproxy-server-windows-amd64.exe
 
 **Docker**
-
-**NOTE**: Until https://github.com/Shopify/toxiproxy/issues/159 is fixed in
-`2.1.1` we recommend using the `2.0.0` release.
 
 Toxiproxy is available on [Docker Hub](https://hub.docker.com/r/shopify/toxiproxy/).
 


### PR DESCRIPTION
Reverts Shopify/toxiproxy#162

I was able to reproduce the https://github.com/Shopify/toxiproxy/issues/159 bug in toxiproxy version 2.0.0 on sha 711c9e48311da6f5f4a9f7e89ee4d00c68011c94.

My understanding of the bug is that it has existed ever since the timeout toxic was introduced. The timeout toxic doesn't read input data and other toxics like latency always write output data. This behaviour fundamentally creates the hang. The latency toxic attempts to write data to the timeout toxic and blocks forever.

@sirupsen 