### PR TITLE
Timeout hang bug

### DIFF
--- a/link.go
+++ b/link.go
@@ -123,6 +123,15 @@ func (link *ToxicLink) RemoveToxic(toxic *toxics.ToxicWrapper) {
 	i := toxic.Index
 
 	if link.stubs[i].InterruptToxic() {
+		cleanup, ok := toxic.Toxic.(toxics.CleanupToxic)
+		if ok {
+			cleanup.Cleanup(link.stubs[i])
+			// Cleanup could have closed the stub.
+			if link.stubs[i].Closed() {
+				return
+			}
+		}
+
 		stop := make(chan bool)
 		// Interrupt the previous toxic to update its output
 		go func() {

--- a/testhelper/testhelper.go
+++ b/testhelper/testhelper.go
@@ -1,0 +1,20 @@
+package testhelper
+
+import (
+	"time"
+  "fmt"
+)
+
+func TimeoutAfter(after time.Duration, f func()) error {
+	success := make(chan struct{})
+	go func() {
+		f()
+		close(success)
+	}()
+	select {
+	case <-success:
+		return nil
+	case <-time.After(after):
+		return fmt.Errorf("timed out after %s", after)
+	}
+}

--- a/testhelper/testhelper_test.go
+++ b/testhelper/testhelper_test.go
@@ -1,0 +1,20 @@
+package testhelper
+
+import (
+  "testing"
+  "time"
+)
+
+func TestTimeoutAfter(t *testing.T) {
+  err := TimeoutAfter(5*time.Millisecond, func() {})
+  if err != nil {
+    t.Fatal("Non blocking function should not timeout.")
+  }
+
+  err = TimeoutAfter(5*time.Millisecond, func() {
+    time.Sleep(time.Second)
+  })
+  if err == nil {
+    t.Fatal("Blocking function should timeout.")
+  }
+}

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -19,10 +19,10 @@ import (
 type ToxicCollection struct {
 	sync.Mutex
 
-	noop   *toxics.ToxicWrapper
-	proxy  *Proxy
-	chain  [][]*toxics.ToxicWrapper
-	links  map[string]*ToxicLink
+	noop  *toxics.ToxicWrapper
+	proxy *Proxy
+	chain [][]*toxics.ToxicWrapper
+	links map[string]*ToxicLink
 }
 
 func NewToxicCollection(proxy *Proxy) *ToxicCollection {
@@ -31,9 +31,9 @@ func NewToxicCollection(proxy *Proxy) *ToxicCollection {
 			Toxic: new(toxics.NoopToxic),
 			Type:  "noop",
 		},
-		proxy:  proxy,
-		chain:  make([][]*toxics.ToxicWrapper, stream.NumDirections),
-		links:  make(map[string]*ToxicLink),
+		proxy: proxy,
+		chain: make([][]*toxics.ToxicWrapper, stream.NumDirections),
+		links: make(map[string]*ToxicLink),
 	}
 	for dir := range collection.chain {
 		collection.chain[dir] = make([]*toxics.ToxicWrapper, 1, toxics.Count()+1)

--- a/toxics/timeout_test.go
+++ b/toxics/timeout_test.go
@@ -1,9 +1,10 @@
 package toxics_test
 
 import (
-  "testing"
-  "net"
-  "time"
+	"io"
+	"net"
+	"testing"
+	"time"
 
 	"github.com/Shopify/toxiproxy/toxics"
 )
@@ -19,8 +20,8 @@ func TestTimeoutToxicDoesNotCauseHang(t *testing.T) {
 	proxy.Start()
 	defer proxy.Stop()
 
-  proxy.Toxics.AddToxicJson(ToxicToJson(t, "might_block", "latency", "upstream", &toxics.LatencyToxic{Latency: 10}))
-  proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
+	proxy.Toxics.AddToxicJson(ToxicToJson(t, "might_block", "latency", "upstream", &toxics.LatencyToxic{Latency: 10}))
+	proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
 
 	serverConnRecv := make(chan net.Conn)
 	go func() {
@@ -31,31 +32,86 @@ func TestTimeoutToxicDoesNotCauseHang(t *testing.T) {
 		serverConnRecv <- conn
 	}()
 
-  conn, err := net.Dial("tcp", proxy.Listen)
-  if err != nil {
-    t.Fatal("Unable to dial TCP server", err)
-  }
-  defer conn.Close()
+	conn, err := net.Dial("tcp", proxy.Listen)
+	if err != nil {
+		t.Fatal("Unable to dial TCP server", err)
+	}
+	defer conn.Close()
 
 	_ = <-serverConnRecv
 
-  _, err = conn.Write([]byte("hello"))
-  if err != nil {
-    t.Fatal("Unable to write to proxy", err)
-  }
+	_, err = conn.Write([]byte("hello"))
+	if err != nil {
+		t.Fatal("Unable to write to proxy", err)
+	}
 
-  time.Sleep(1 * time.Second) // Shitty sync waiting for latency toxi to get data.
+	time.Sleep(1 * time.Second) // Shitty sync waiting for latency toxi to get data.
 
-  done := make(chan struct{})
-  go func() {
-    proxy.Toxics.RemoveToxic("might_block")
-    close(done)
-  }()
+	done := make(chan struct{})
+	go func() {
+		proxy.Toxics.RemoveToxic("might_block")
+		close(done)
+	}()
 
-  select {
-  case <-done:
-  case <-time.After(1 * time.Second):
-    t.Fatal("timeout toxic is causing latency toxic to block")
-  }
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout toxic is causing latency toxic to block")
+	}
 }
 
+func TestTimeoutToxicClosesConnectionOnRemove(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal("Failed to create TCP server", err)
+	}
+	defer ln.Close()
+
+	proxy := NewTestProxy("test", ln.Addr().String())
+	proxy.Start()
+	defer proxy.Stop()
+
+	serverConnRecv := make(chan net.Conn)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Error("Unable to accept TCP connection", err)
+		}
+		serverConnRecv <- conn
+	}()
+
+	conn, err := net.Dial("tcp", proxy.Listen)
+	if err != nil {
+		t.Fatal("Unable to dial TCP server", err)
+	}
+	defer conn.Close()
+
+	serverConn := <-serverConnRecv
+	defer serverConn.Close()
+
+	// Send data on connection to confirm link is established.
+	conn.Write([]byte("foobar"))
+	buf := make([]byte, 6)
+	serverConn.Read(buf)
+
+	proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
+
+	proxy.Toxics.RemoveToxic("to_delete")
+
+	closed := make(chan error)
+
+	go func() {
+		buf = make([]byte, 1)
+		_, err = conn.Read(buf)
+		closed <- err
+	}()
+
+	select {
+	case err := <-closed:
+		if err != io.EOF {
+			t.Fatal("expected EOF from closed connetion")
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("connection was not closed in time")
+	}
+}

--- a/toxics/timeout_test.go
+++ b/toxics/timeout_test.go
@@ -1,62 +1,18 @@
 package toxics_test
 
 import (
+	"bytes"
 	"io"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/Shopify/toxiproxy"
 	"github.com/Shopify/toxiproxy/testhelper"
 	"github.com/Shopify/toxiproxy/toxics"
 )
 
-func TestTimeoutToxicDoesNotCauseHang(t *testing.T) {
-	ln, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatal("Failed to create TCP server", err)
-	}
-	defer ln.Close()
-
-	proxy := NewTestProxy("test", ln.Addr().String())
-	proxy.Start()
-	defer proxy.Stop()
-
-	proxy.Toxics.AddToxicJson(ToxicToJson(t, "might_block", "latency", "upstream", &toxics.LatencyToxic{Latency: 10}))
-	proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
-
-	serverConnRecv := make(chan net.Conn)
-	go func() {
-		conn, err := ln.Accept()
-		if err != nil {
-			t.Error("Unable to accept TCP connection", err)
-		}
-		serverConnRecv <- conn
-	}()
-
-	conn, err := net.Dial("tcp", proxy.Listen)
-	if err != nil {
-		t.Fatal("Unable to dial TCP server", err)
-	}
-	defer conn.Close()
-
-	_ = <-serverConnRecv
-
-	_, err = conn.Write([]byte("hello"))
-	if err != nil {
-		t.Fatal("Unable to write to proxy", err)
-	}
-
-	time.Sleep(1 * time.Second) // Shitty sync waiting for latency toxi to get data.
-
-	err = testhelper.TimeoutAfter(time.Second, func() {
-		proxy.Toxics.RemoveToxic("might_block")
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestTimeoutToxicClosesConnectionOnRemove(t *testing.T) {
+func WithEstablishedProxy(t *testing.T, f func(net.Conn, net.Conn, *toxiproxy.Proxy)) {
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatal("Failed to create TCP server", err)
@@ -85,23 +41,72 @@ func TestTimeoutToxicClosesConnectionOnRemove(t *testing.T) {
 	serverConn := <-serverConnRecv
 	defer serverConn.Close()
 
-	// Send data on connection to confirm link is established.
-	conn.Write([]byte("foobar"))
-	buf := make([]byte, 6)
-	serverConn.Read(buf)
+	writeAndReceive := func(from, to net.Conn) {
+		data := []byte("foobar")
+		_, err := from.Write(data)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
+		err = testhelper.TimeoutAfter(time.Second, func() {
+			resp := make([]byte, len(data))
+			to.Read(resp)
+			if !bytes.Equal(resp, data) {
+				t.Fatalf("expected '%s' but got '%s'", string(data), string(resp))
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 
-	proxy.Toxics.RemoveToxic("to_delete")
+	// Make sure we can send and receive data before continuing.
+	writeAndReceive(conn, serverConn)
+	writeAndReceive(serverConn, conn)
 
-	err = testhelper.TimeoutAfter(time.Second, func() {
-		buf = make([]byte, 1)
-		_, err = conn.Read(buf)
-		if err != io.EOF {
-			t.Fatal("expected EOF from closed connetion")
+	f(conn, serverConn, proxy)
+}
+
+func TestTimeoutToxicDoesNotCauseHang(t *testing.T) {
+	WithEstablishedProxy(t, func(conn, _ net.Conn, proxy *toxiproxy.Proxy) {
+		proxy.Toxics.AddToxicJson(ToxicToJson(t, "might_block", "latency", "upstream", &toxics.LatencyToxic{Latency: 10}))
+		proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
+
+		_, err := conn.Write([]byte("hello"))
+		if err != nil {
+			t.Fatal("Unable to write to proxy", err)
+		}
+
+		time.Sleep(1 * time.Second) // Shitty sync waiting for latency toxi to get data.
+
+		err = testhelper.TimeoutAfter(time.Second, func() {
+			proxy.Toxics.RemoveToxic("might_block")
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+}
+
+func TestTimeoutToxicClosesConnectionOnRemove(t *testing.T) {
+	WithEstablishedProxy(t, func(conn, serverConn net.Conn, proxy *toxiproxy.Proxy) {
+		proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
+
+		proxy.Toxics.RemoveToxic("to_delete")
+
+		err := testhelper.TimeoutAfter(time.Second, func() {
+			buf := make([]byte, 1)
+			_, err := conn.Read(buf)
+			if err != io.EOF {
+				t.Fatal("expected EOF from closed connetion")
+			}
+			_, err = serverConn.Read(buf)
+			if err != io.EOF {
+				t.Fatal("expected EOF from closed server connetion")
+			}
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/toxics/timeout_test.go
+++ b/toxics/timeout_test.go
@@ -1,0 +1,61 @@
+package toxics_test
+
+import (
+  "testing"
+  "net"
+  "time"
+
+	"github.com/Shopify/toxiproxy/toxics"
+)
+
+func TestTimeoutToxicDoesNotCauseHang(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal("Failed to create TCP server", err)
+	}
+	defer ln.Close()
+
+	proxy := NewTestProxy("test", ln.Addr().String())
+	proxy.Start()
+	defer proxy.Stop()
+
+  proxy.Toxics.AddToxicJson(ToxicToJson(t, "might_block", "latency", "upstream", &toxics.LatencyToxic{Latency: 10}))
+  proxy.Toxics.AddToxicJson(ToxicToJson(t, "to_delete", "timeout", "upstream", &toxics.TimeoutToxic{Timeout: 0}))
+
+	serverConnRecv := make(chan net.Conn)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Error("Unable to accept TCP connection", err)
+		}
+		serverConnRecv <- conn
+	}()
+
+  conn, err := net.Dial("tcp", proxy.Listen)
+  if err != nil {
+    t.Fatal("Unable to dial TCP server", err)
+  }
+  defer conn.Close()
+
+	_ = <-serverConnRecv
+
+  _, err = conn.Write([]byte("hello"))
+  if err != nil {
+    t.Fatal("Unable to write to proxy", err)
+  }
+
+  time.Sleep(1 * time.Second) // Shitty sync waiting for latency toxi to get data.
+
+  done := make(chan struct{})
+  go func() {
+    proxy.Toxics.RemoveToxic("might_block")
+    close(done)
+  }()
+
+  select {
+  case <-done:
+  case <-time.After(1 * time.Second):
+    t.Fatal("timeout toxic is causing latency toxic to block")
+  }
+}
+

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -26,6 +26,11 @@ type Toxic interface {
 	Pipe(*ToxicStub)
 }
 
+type CleanupToxic interface {
+	// Cleanup is called before a toxic is removed.
+	Cleanup(*ToxicStub)
+}
+
 type BufferedToxic interface {
 	// Defines the size of buffer this toxic should use
 	GetBufferSize() int
@@ -92,9 +97,20 @@ func (s *ToxicStub) InterruptToxic() bool {
 	}
 }
 
+func (s *ToxicStub) Closed() bool {
+	select {
+	case <-s.closed:
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *ToxicStub) Close() {
-	close(s.closed)
-	close(s.Output)
+	if !s.Closed() {
+		close(s.closed)
+		close(s.Output)
+	}
 }
 
 var ToxicRegistry map[string]Toxic


### PR DESCRIPTION
This is a proposed fix to the API hang bug from issue https://github.com/Shopify/toxiproxy/issues/159.

### Overview of what this PR does.
- [Adds a regression test for the bug mentioned above.](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/toxics/timeout_test.go#L12)
- Fixes the bug by [changing the `timeout` toxic to drop incoming tcp data](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/toxics/timeout.go#L22-L31) on the ground.
- The `timeout` toxic implements [`CleanupToxic`](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/toxics/toxic.go#L29-L32) and [closes it's connection](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/toxics/timeout.go#L36-L38) on cleanup to avoid stream corruption because of dropped data.
- Toxiproxy calls `Cleanup` when a toxic is deleted and it implements the [`CleanupToxic`](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/toxics/toxic.go#L29-L32) interface.
- [Adds a test to confirm open connections are closed when a `timeout` toxic is deleted.](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/toxics/timeout_test.go#L63)
- [Fixes a test so that it fails gracefully rather than hanging forever.](https://github.com/Shopify/toxiproxy/blob/f7154cc4ffa799707070e94f671e3abf1fbcace8/link_test.go#L194-L211)

### TLDR of Bug (Described in issue https://github.com/Shopify/toxiproxy/issues/159.)
1. Toxics that occur before the `timeout` toxic attempt to forward TCP data to the `timeout` toxic.
2. Because the `timeout` toxic does not read incoming data, these forwarding toxics block forever.
3. When an API call deletes a toxic, it attempts to interrupt the toxic but this interrupt hangs forever because the toxic is blocked attempting to forward data to the `timeout` toxic.

### TLDR of Fix (Described in comment https://github.com/Shopify/toxiproxy/issues/159#issuecomment-287588933.)
We make the `timeout` toxic read incoming data so that writers don't block forever. The `timeout` toxic then ignores this data ("drops it on the ground"). Because the data is dropped on the ground, this corrupts the TCP stream so the connection needs to be closed when the `timeout` toxic is deleted.

### Does this break backwards compatibility?
Yes but not in realistic use cases. If you remove a `timeout` toxic, connections to this proxy will be closed. Before this change, data blocked by the `timeout` toxic would be forwarded after its deletion. (Assuming this hang bug was not encountered.). IMO the new behaviour is the correct behaviour because `timeout` implies the connection will be closed. If you want long delays, use a large value on a `latency` toxic.