### PR TITLE
timeout toxic drops more than just the first segment

### DIFF
--- a/toxics/timeout.go
+++ b/toxics/timeout.go
@@ -24,11 +24,13 @@ func (t *TimeoutToxic) Pipe(stub *ToxicStub) {
 			}
 		}
 	} else {
-		select {
-		case <-stub.Interrupt:
-			return
-		case <-stub.Input:
-			// Drop the data on the ground.
+		for {
+			select {
+			case <-stub.Interrupt:
+				return
+			case <-stub.Input:
+				// Drop the data on the ground.
+			}
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/Shopify/toxiproxy/pull/168 introduced a bug where `timeout` toxics would drop the first segment it received but not future segments.

This is because I did not put a for loop around the select statement.

Quite amazingly, this was NOT caught by the regression test because the regression test only sends one segment rather than multiple.

### What does this PR do?

- Updates the regression test to send multiple segments.
- Wraps the `timeout` select statement in a for loop.

Here's a screen shot of me attempting to recreate the bug with this branch. Notice that the client does not hang when deleting the latency toxic, proving that https://github.com/Shopify/toxiproxy/issues/159 was indeed fixed.

<img width="1430" alt="screen shot 2017-04-04 at 7 26 21 pm" src="https://cloud.githubusercontent.com/assets/5767836/24683368/a68aa470-196c-11e7-9cf2-b29d9952148a.png">

@sirupsen
