### PR TITLE
only prepend `http://` to endpoint if no protocol was provided

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
+	"regexp"
 )
 
 // Client holds information about where to connect to Toxiproxy.
@@ -47,7 +47,8 @@ type Proxy struct {
 // with Toxiproxy. Endpoint is the address to the proxy (e.g. localhost:8474 if
 // not overriden)
 func NewClient(endpoint string) *Client {
-	if !strings.HasPrefix(endpoint, "http://") {
+	protocolProvided, _ := regexp.MatchString(`^https?://`, endpoint)
+	if !protocolProvided {
 		endpoint = "http://" + endpoint
 	}
 	return &Client{endpoint: endpoint}

--- a/client/client.go
+++ b/client/client.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
-	"regexp"
+	"strings"
 )
 
 // Client holds information about where to connect to Toxiproxy.
@@ -47,8 +48,9 @@ type Proxy struct {
 // with Toxiproxy. Endpoint is the address to the proxy (e.g. localhost:8474 if
 // not overriden)
 func NewClient(endpoint string) *Client {
-	protocolProvided, _ := regexp.MatchString(`^https?://`, endpoint)
-	if !protocolProvided {
+	if strings.HasPrefix(endpoint, "https://") {
+		log.Fatal("the toxiproxy client does not support https")
+	} else if !strings.HasPrefix(endpoint, "http://") {
 		endpoint = "http://" + endpoint
 	}
 	return &Client{endpoint: endpoint}


### PR DESCRIPTION
Hey,
this addresses the fix mentioned in #174: Although the Toxiproxy HTTP API does not support HTTPS, it should not prepend `http://` to the endpoint.

```go
client.NewClient("https://example.com")
// Before: http://https//example.com
// After: https://example.com
```
I would love to write a test for this but `endpoint` is not an exported identifier so i'm not sure how to test this as this is basically the first Go code that i have ever written 🙂 

fixes #174