### PR TITLE
add support for toxiproxy-haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ development and CI environments.
 * [toxiproxy-php-client](https://github.com/ihsw/toxiproxy-php-client)
 * [toxiproxy-node-client](https://github.com/ihsw/toxiproxy-node-client)
 * [toxiproxy-java](https://github.com/trekawek/toxiproxy-java)
+* [toxiproxy-haskell](https://github.com/jpittis/toxiproxy-haskell)
 
 ## Example
 

--- a/api.go
+++ b/api.go
@@ -382,7 +382,7 @@ func (server *ApiServer) ToxicDelete(response http.ResponseWriter, request *http
 }
 
 func (server *ApiServer) Version(response http.ResponseWriter, request *http.Request) {
-	response.Header().Set("Content-Type", "text/plain")
+	response.Header().Set("Content-Type", "text/plain;charset=utf-8")
 	_, err := response.Write([]byte(Version))
 	if err != nil {
 		logrus.Warn("Version: Failed to write response to client", err)


### PR DESCRIPTION
I've written a Haskell Toxiproxy client.

It's well tested. (Complete test suite for every endpoint of the API.) So I believe it's appropriate to add to the list of client libraries.

The Haskell HTTP client library I used requires the "text/plain" content type to be labeled with a charset. I think it's reasonable that we expect our version number to be valid utf-8. I've updated the `Content-Type` field of `Version` to specify a charset.

@sirupsen 