### PR TITLE
Populate toxics at startup from a json string

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,8 +288,11 @@ Toxiproxy.
 For large application we recommend storing the Toxiproxy configurations in a
 separate configuration file. We use `config/toxiproxy.json`. This file can be
 passed to the server using the `-configFile` option, or loaded by the application
-to use with the `populate` function. Alternatively you can pass a json string 
-with the `-configJson` option to populate these configurations.
+to use with the `populate` function.
+Alternatively you can pass a json string with the `-configJson` option to populate
+these configurations. This is specially useful when running Toxiproxy as a docker container, e.g.:
+
+```docker run -it shopify/toxiproxy -configJson '[{"name": "redis","listen": "0.0.0.0:9092","upstream": "redis:6379"}]'```
 
 Use ports outside the ephemeral port range to avoid random port conflicts.
 It's `32,768` to `61,000` on Linux by default, see

--- a/README.md
+++ b/README.md
@@ -287,8 +287,9 @@ Toxiproxy.
 
 For large application we recommend storing the Toxiproxy configurations in a
 separate configuration file. We use `config/toxiproxy.json`. This file can be
-passed to the server using the `-config` option, or loaded by the application
-to use with the `populate` function.
+passed to the server using the `-configFile` option, or loaded by the application
+to use with the `populate` function. Alternatively you can pass a json string 
+with the `-configJson` option to populate these configurations.
 
 Use ports outside the ephemeral port range to avoid random port conflicts.
 It's `32,768` to `61,000` on Linux by default, see

--- a/api_test.go
+++ b/api_test.go
@@ -323,7 +323,7 @@ func TestPopulateProxyWithBadDataShouldReturnError(t *testing.T) {
 
 		for _, p := range proxies {
 			if p.Name == "two" || p.Name == "three" {
-				t.Fatalf("Proxy %s exists, populate did not fail correctly.")
+				t.Fatalf("Proxy %s exists, populate did not fail correctly.", p.Name)
 			}
 		}
 	})

--- a/cmd/toxiproxy.go
+++ b/cmd/toxiproxy.go
@@ -9,16 +9,19 @@ import (
 	"time"
 
 	"github.com/Shopify/toxiproxy"
+	"github.com/sirupsen/logrus"
 )
 
 var host string
 var port string
-var config string
+var configJson string
+var configFile string
 
 func init() {
 	flag.StringVar(&host, "host", "localhost", "Host for toxiproxy's API to listen on")
 	flag.StringVar(&port, "port", "8474", "Port for toxiproxy's API to listen on")
-	flag.StringVar(&config, "config", "", "JSON file containing proxies to create on startup")
+	flag.StringVar(&configFile, "configFile", "", "JSON file containing proxies to create on startup")
+	flag.StringVar(&configJson, "configJson", "", "JSON literal containing proxies to create on startup")
 	seed := flag.Int64("seed", time.Now().UTC().UnixNano(), "Seed for randomizing toxics with")
 	flag.Parse()
 	rand.Seed(*seed)
@@ -26,8 +29,19 @@ func init() {
 
 func main() {
 	server := toxiproxy.NewServer()
-	if len(config) > 0 {
-		server.PopulateConfig(config)
+
+	if len(configFile) > 0 && len(configJson) > 0 {
+		logrus.WithFields(logrus.Fields{
+			"configFile": configFile,
+			"configJson": configJson,
+		}).Error("configFile and configJson are mutually exclusive")
+	} else {
+		if len(configFile) > 0 {
+			server.PopulateConfigFromFile(configFile)
+		}
+		if len(configJson) > 0 {
+			server.PopulateConfigFromJsonString(configJson)
+		}
 	}
 
 	// Handle SIGTERM to exit cleanly


### PR DESCRIPTION
# Ability to provide a configuration at startup.
My use case is the following:
I'm running a Kuberneters cluster with several applications/containers deployed. I would like to use Toxiproxy as a sidecar to some of these applications to be able to perform failure testing.

Currently we have two existing options to populate proxies, one from a json file and by making an http request. Neither option is very friendly when using Toxiproxy on containerized environments as they either require a post start script to run the http populate request or mounting a volume with the json config file.

With this change we can provide a json string (at startup) as such:
`docker run -it shopify/toxiproxy:git -configJson '[{"name": "redis","listen": "0.0.0.0:9092","upstream": "redis:6379"}]'`