### PR TITLE
Update CircleCI config to 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.10.2
+
+    working_directory: /go/src/github.com/Shopify/toxiproxy
+
+    environment:
+      TEST_RESULTS: /tmp/test-results
+
+    steps:
+      - checkout
+      - run: mkdir -p $TEST_RESULTS
+      - run: go get github.com/jstemmer/go-junit-report
+      - run:
+          name: Run unit tests
+          command: |
+            trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+            make test | tee ${TEST_RESULTS}/go-test.out
+
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-# Don't let Circle try to do anything clever with this Go project. We isolate
-# with godep to avoid `go get` going nuts.
-dependencies:
-  override:
-
-test:
-  override:
-    - make test

--- a/link_test.go
+++ b/link_test.go
@@ -223,3 +223,7 @@ func TestStateCreated(t *testing.T) {
 		t.Fatalf("New toxic did not have state object created.")
 	}
 }
+
+func TestFailingTest(t *testing.T) {
+	t.Fatal("This is a failing test.")
+}

--- a/link_test.go
+++ b/link_test.go
@@ -223,7 +223,3 @@ func TestStateCreated(t *testing.T) {
 		t.Fatalf("New toxic did not have state object created.")
 	}
 }
-
-func TestFailingTest(t *testing.T) {
-	t.Fatal("This is a failing test.")
-}


### PR DESCRIPTION
I added go-junit-report as well to make reading the output a little easier.

Verified with an explicit failing test:
https://circleci.com/gh/Shopify/toxiproxy/tree/circle2_test

Will squash before merging.

@jpittis @sirupsen 