### PR TITLE
Bail out of the loop when the stub Input stream is done

### DIFF
--- a/toxics/timeout.go
+++ b/toxics/timeout.go
@@ -21,6 +21,7 @@ func (t *TimeoutToxic) Pipe(stub *ToxicStub) {
 				return
 			case c := <-stub.Input:
 				if c == nil {
+					stub.Close()
 					return
 				}
 				// Drop the data on the ground.
@@ -31,7 +32,11 @@ func (t *TimeoutToxic) Pipe(stub *ToxicStub) {
 			select {
 			case <-stub.Interrupt:
 				return
-			case <-stub.Input:
+			case c := <-stub.Input:
+				if c == nil {
+					stub.Close()
+					return
+				}
 				// Drop the data on the ground.
 			}
 		}

--- a/toxics/timeout.go
+++ b/toxics/timeout.go
@@ -19,7 +19,10 @@ func (t *TimeoutToxic) Pipe(stub *ToxicStub) {
 				return
 			case <-stub.Interrupt:
 				return
-			case <-stub.Input:
+			case c := <-stub.Input:
+				if c == nil {
+					return
+				}
 				// Drop the data on the ground.
 			}
 		}


### PR DESCRIPTION
This PR fixes
 - the OOM caused by unnecessary creation of timer objects even after the request/response is completed. 
Find pprof attached that shows before and after the fix.

Before:
![image](https://user-images.githubusercontent.com/5277395/47092860-d7bb5e00-d21f-11e8-8f26-ef75ee34e0ff.png)

After:
![image](https://user-images.githubusercontent.com/5277395/47092919-f3266900-d21f-11e8-8d05-6f352438b792.png)
