### PR TITLE
Add client address to ToxicStub to enable client aware toxics

### DIFF
--- a/link_test.go
+++ b/link_test.go
@@ -19,7 +19,7 @@ func TestToxicsAreLoaded(t *testing.T) {
 
 func TestStubInitializaation(t *testing.T) {
 	collection := NewToxicCollection(nil)
-	link := NewToxicLink(nil, collection, stream.Downstream)
+	link := NewToxicLink(nil, collection, stream.Downstream, "localhost")
 	if len(link.stubs) != 1 {
 		t.Fatalf("Link created with wrong number of stubs: %d != 1", len(link.stubs))
 	} else if cap(link.stubs) != toxics.Count()+1 {
@@ -31,7 +31,7 @@ func TestStubInitializaation(t *testing.T) {
 	}
 }
 
-func TestStubInitializaationWithToxics(t *testing.T) {
+func TestStubInitializationWithToxics(t *testing.T) {
 	collection := NewToxicCollection(nil)
 	collection.chainAddToxic(&toxics.ToxicWrapper{
 		Toxic:      new(toxics.LatencyToxic),
@@ -46,7 +46,7 @@ func TestStubInitializaationWithToxics(t *testing.T) {
 		Direction: stream.Downstream,
 		Toxicity:  1,
 	})
-	link := NewToxicLink(nil, collection, stream.Downstream)
+	link := NewToxicLink(nil, collection, stream.Downstream, "localhost")
 	if len(link.stubs) != 3 {
 		t.Fatalf("Link created with wrong number of stubs: %d != 3", len(link.stubs))
 	} else if cap(link.stubs) != toxics.Count()+1 {
@@ -63,7 +63,7 @@ func TestStubInitializaationWithToxics(t *testing.T) {
 
 func TestAddRemoveStubs(t *testing.T) {
 	collection := NewToxicCollection(nil)
-	link := NewToxicLink(nil, collection, stream.Downstream)
+	link := NewToxicLink(nil, collection, stream.Downstream, "localhost")
 	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
 	collection.links["test"] = link
 
@@ -106,7 +106,7 @@ func TestAddRemoveStubs(t *testing.T) {
 
 func TestNoDataDropped(t *testing.T) {
 	collection := NewToxicCollection(nil)
-	link := NewToxicLink(nil, collection, stream.Downstream)
+	link := NewToxicLink(nil, collection, stream.Downstream, "localhost")
 	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
 	collection.links["test"] = link
 
@@ -162,7 +162,7 @@ func TestNoDataDropped(t *testing.T) {
 
 func TestToxicity(t *testing.T) {
 	collection := NewToxicCollection(nil)
-	link := NewToxicLink(nil, collection, stream.Downstream)
+	link := NewToxicLink(nil, collection, stream.Downstream, "localhost")
 	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
 	collection.links["test"] = link
 
@@ -209,7 +209,7 @@ func TestToxicity(t *testing.T) {
 
 func TestStateCreated(t *testing.T) {
 	collection := NewToxicCollection(nil)
-	link := NewToxicLink(nil, collection, stream.Downstream)
+	link := NewToxicLink(nil, collection, stream.Downstream, "localhost")
 	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
 	collection.links["test"] = link
 

--- a/proxy.go
+++ b/proxy.go
@@ -176,8 +176,8 @@ func (proxy *Proxy) server() {
 		proxy.connections.list[name+"upstream"] = upstream
 		proxy.connections.list[name+"downstream"] = client
 		proxy.connections.Unlock()
-		proxy.Toxics.StartLink(name+"upstream", client, upstream, stream.Upstream)
-		proxy.Toxics.StartLink(name+"downstream", upstream, client, stream.Downstream)
+		proxy.Toxics.StartLink(name+"upstream", client, upstream, stream.Upstream, client.RemoteAddr().String())
+		proxy.Toxics.StartLink(name+"downstream", upstream, client, stream.Downstream, client.RemoteAddr().String())
 	}
 }
 

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -169,11 +169,11 @@ func (c *ToxicCollection) RemoveToxic(name string) error {
 	return ErrToxicNotFound
 }
 
-func (c *ToxicCollection) StartLink(name string, input io.Reader, output io.WriteCloser, direction stream.Direction) {
+func (c *ToxicCollection) StartLink(name string, input io.Reader, output io.WriteCloser, direction stream.Direction, clientAddress string) {
 	c.Lock()
 	defer c.Unlock()
 
-	link := NewToxicLink(c.proxy, c, direction)
+	link := NewToxicLink(c.proxy, c, direction, clientAddress)
 	link.Start(name, input, output)
 	c.links[name] = link
 }

--- a/toxics/limit_data_test.go
+++ b/toxics/limit_data_test.go
@@ -33,7 +33,7 @@ func checkRemainingChunks(t *testing.T, output chan *stream.StreamChunk) {
 func check(t *testing.T, toxic *toxics.LimitDataToxic, chunks [][]byte, expectedChunks [][]byte) {
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk, 100)
-	stub := toxics.NewToxicStub(input, output)
+	stub := toxics.NewToxicStub(input, output, toxics.ClientInfo{Address: "localhost"})
 	stub.State = toxic.NewState()
 
 	go toxic.Pipe(stub)
@@ -54,7 +54,7 @@ func TestLimitDataToxicMayBeRestarted(t *testing.T) {
 
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk, 100)
-	stub := toxics.NewToxicStub(input, output)
+	stub := toxics.NewToxicStub(input, output, toxics.ClientInfo{Address:"localhost"})
 	stub.State = toxic.NewState()
 
 	buf := buffer(90)
@@ -85,7 +85,7 @@ func TestLimitDataToxicMayBeInterrupted(t *testing.T) {
 
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk)
-	stub := toxics.NewToxicStub(input, output)
+	stub := toxics.NewToxicStub(input, output, toxics.ClientInfo{"localhost"})
 	stub.State = toxic.NewState()
 
 	go func() {
@@ -100,7 +100,7 @@ func TestLimitDataToxicNilShouldClosePipe(t *testing.T) {
 
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk)
-	stub := toxics.NewToxicStub(input, output)
+	stub := toxics.NewToxicStub(input, output, toxics.ClientInfo{Address: "localhost"})
 	stub.State = toxic.NewState()
 
 	go func() {

--- a/toxics/slicer_test.go
+++ b/toxics/slicer_test.go
@@ -16,7 +16,9 @@ func TestSlicerToxic(t *testing.T) {
 
 	input := make(chan *stream.StreamChunk)
 	output := make(chan *stream.StreamChunk)
-	stub := toxics.NewToxicStub(input, output)
+	stub := toxics.NewToxicStub(input, output, toxics.ClientInfo{
+		Address: "localhost",
+	})
 
 	done := make(chan bool)
 	go func() {

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Shopify/toxiproxy/stream"
 )
 
-// A Toxic is something that can be attatched to a link to modify the way
+// A Toxic is something that can be attached to a link to modify the way
 // data can be passed through (for example, by adding latency)
 //
 //              Toxic
@@ -62,14 +62,20 @@ type ToxicStub struct {
 	Interrupt chan struct{}
 	running   chan struct{}
 	closed    chan struct{}
+	clientInfo ClientInfo
 }
 
-func NewToxicStub(input <-chan *stream.StreamChunk, output chan<- *stream.StreamChunk) *ToxicStub {
+type ClientInfo struct {
+	Address string
+}
+
+func NewToxicStub(input <-chan *stream.StreamChunk, output chan<- *stream.StreamChunk, clientInfo ClientInfo) *ToxicStub {
 	return &ToxicStub{
 		Interrupt: make(chan struct{}),
 		closed:    make(chan struct{}),
 		Input:     input,
 		Output:    output,
+		clientInfo: clientInfo,
 	}
 }
 


### PR DESCRIPTION
This seemed the simplest way of doing this and I've written toxics that enable me to mimic mis-behaving nodes in an Akka Cluster (P2P clustering). 

I haven't written golang in years so apologies for any atrocities :) 

Refs #244