### PR TITLE
Add the run command for OSX installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ $ sudo service toxiproxy start
 ```bash
 $ brew tap shopify/shopify
 $ brew install toxiproxy
+$ toxiproxy-server
 ```
 
 **Windows**


### PR DESCRIPTION
I found that the README didn't mention that you have to run `toxiproxy-server` and was stuck on this for awhile. This PR adds that you have to run `toxiproxy-server` as a step for the Mac OSX installation. As most of the other installation sections have you run the service.