### PR TITLE
Pull base image by digest and not tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine
+# Alpine 3.10.3
+FROM alpine@sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a
 
 COPY tmp/build/toxiproxy-server-linux-amd64 /go/bin/toxiproxy
 COPY tmp/build/toxiproxy-cli-linux-amd64 /go/bin/toxiproxy-cli


### PR DESCRIPTION
Very small change. Pulling image by digest instead of tag to have a deterministic (and safer) build.

I'm using the latest alpine (https://hub.docker.com/layers/alpine/library/alpine/3.10.3/images/sha256-e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a)