### PR TITLE
Add Rust client link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ development and CI environments.
 * [toxiproxy-node-client](https://github.com/ihsw/toxiproxy-node-client)
 * [toxiproxy-java](https://github.com/trekawek/toxiproxy-java)
 * [toxiproxy-haskell](https://github.com/jpittis/toxiproxy-haskell)
+* [toxiproxy-rust](https://github.com/itarato/toxiproxy_rust)
 
 ## Example
 


### PR DESCRIPTION
This PR adds a [rust client](https://github.com/itarato/toxiproxy_rust) to the readme: [docs](https://docs.rs/toxiproxy_rust/0.1.6/toxiproxy_rust/).

To verify: is the client appropriate to link?