### PR TITLE
Make it build for arm64 (to make it run on Mac M1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM alpine
+FROM alpine:3.11.11
+ARG TARGETARCH
 
-COPY tmp/build/toxiproxy-server-linux-amd64 /go/bin/toxiproxy
-COPY tmp/build/toxiproxy-cli-linux-amd64 /go/bin/toxiproxy-cli
+COPY tmp/build/toxiproxy-server-linux-$TARGETARCH /go/bin/toxiproxy
+COPY tmp/build/toxiproxy-cli-linux-$TARGETARCH /go/bin/toxiproxy-cli
 
 EXPOSE 8474
 ENTRYPOINT ["/go/bin/toxiproxy"]


### PR DESCRIPTION
This PR extends the docker image with an arm64 binary so it can run without emulation on M1 mac.