### PR TITLE
Fixing dev.yml to allow running 'dev up'

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,6 @@ type: go
 
 up:
   - homebrew:
-    - openssl
     - gnu-tar
   - go:
       version: 1.12


### PR DESCRIPTION
Small one, I was just getting to know `dev` and I saw the following error popping up:

 ![image](https://user-images.githubusercontent.com/2609731/130077160-b6137f04-adbc-4898-9b9f-61b8133e7097.png)

Removing the line `- openssl` fixed the issue.