### PR TITLE
Support solaris platform

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ builds:
       - linux
       - netbsd
       - openbsd
+      - solaris
       - windows
 
     goarch:


### PR DESCRIPTION
Build binaries for solaris.

Goreleaser logs:

      • building                  binary=.../dist/toxiproxy-client-solaris-amd64

Fixes #248