### PR TITLE
Update release changelog generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,18 @@ jobs:
           go-version: 1.17
 
       -
+        name: Build release changelog
+        run: |
+          version=${GITHUB_REF#refs/tags/v*}
+          mkdir -p tmp
+          sed '/^# \['$version'\]/,/^# \[/!d;//d;/^\s*$/d' CHANGELOG.md > tmp/release_changelog.md
+
+      -
         name: Release
         uses: goreleaser/goreleaser-action@5a54d7e660bda43b405e8463261b3d25631ffe86
         with:
           distribution: goreleaser
           version: v0.176.0
-          args: release --rm-dist
+          args: release --rm-dist --release-notes=tmp/release_changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 
 # go mod dependencies
 vendor/
+
+tmp/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ builds:
   - <<: *build_default
     id: client
     main: ./cli
-    binary: toxiproxy-client-{{.Os}}-{{.Arch}}
+    binary: toxiproxy-cli-{{.Os}}-{{.Arch}}
 
 checksum:
   name_template: checksums.txt
@@ -125,6 +125,7 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^Merge'
 
 archives:
   -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [Unreleased]
 
+* Use CHANGELOG.md for release description (#306, @miry)
 
 # [2.1.5]
 

--- a/dev.yml
+++ b/dev.yml
@@ -7,5 +7,5 @@ up:
       - gnu-tar
       - goreleaser
   - go:
-      version: 1.16
+      version: 1.17
       modules: true


### PR DESCRIPTION
Currently the `goreleaser` prints all commits.
It also contains the Merge commits from Github.

Example for v2.1.5 would be:

```
## Changelog

* Move to Go Modules from godeps (#253, @epk)
* Update the example in `client/README.md` (#251, @nothinux)
* Update TOC in `README.md` (4ca1eddddfcd0c50c8f6dfb97089bb68e6310fd9, @dwradcliffe)
* Add an example of `config.json` file to `README.md` (#260, @JesseEstum)
* Add Link to Elixir Client (#287, @Jcambass)
* Add Rust client link (#293, @itarato)
* Renovations: formatting code, update dependicies, make govet/staticcheck pass (#294, @dnwe)
* Remove `openssl` from `dev.yml` to use `dev` tool (#298, @pedro-stanaka)
* Update `go` versions in development (#299, @miry)
* Mention `MacPorts` in `README.md` (#290, @amake)
* Fix some typos in `README.md` and `CHANGELOG.md` (#222, @jwilk)
* Replace TravisCI with Github Actions to run tests (#303, @miry)
* Build and release binaries with `goreleaser`. Support `arm64` and BSD oses. (#301, @miry)
* Automate release with Github actions (#304, @miry)
```

Replace this type of CHANGELOG with version used in `CHANGELOG.md`.
Updated release workflow to extract version changes and use it with goreleaser.