### PR TITLE
Flags write before arguments in toxiproxy-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [Unreleased]
 
 * Use CHANGELOG.md for release description (#306, @miry)
-* In #294 introduced a breaking change in client argument parsing. It requires
-  to write [flags before arguments](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#flags-before-args).
-  Update help texts and documentation. (@miry)
+* Dependency updates in #294 introduced a breaking change in CLI argument parsing. Now [flags must be specified before arguments](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#flags-before-args). Previously, arguments could be specified prior to flags.
+  Update usage help text and documentation. (@miry)
 
 # [2.1.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # [Unreleased]
 
 * Use CHANGELOG.md for release description (#306, @miry)
+* In #294 introduced a breaking change in client argument parsing. It requires
+  to write [flags before arguments](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#flags-before-args).
+  Update help texts and documentation. (@miry)
 
 # [2.1.5]
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ documentation on the population helpers.
 Alternatively use the CLI to create proxies, e.g.:
 
 ```bash
-toxiproxy-cli create shopify_test_redis_master -l localhost:26379 -u localhost:6379
+toxiproxy-cli create -l localhost:26379 -u localhost:6379 shopify_test_redis_master
 ```
 
 We recommend a naming such as the above: `<app>_<env>_<data store>_<shard>`.
@@ -351,7 +351,7 @@ end
 Or via the CLI:
 
 ```bash
-toxiproxy-cli toxic add shopify_test_redis_master -t latency -a latency=1000
+toxiproxy-cli toxic add -t latency -a latency=1000 shopify_test_redis_master
 ```
 
 Please consult your respective client library on usage.
@@ -492,7 +492,7 @@ fields are consistent with the new data.
 ### CLI Example
 
 ```bash
-$ toxiproxy-cli create redis -l localhost:26379 -u localhost:6379
+$ toxiproxy-cli create -l localhost:26379 -u localhost:6379 redis
 Created new proxy redis
 $ toxiproxy-cli list
 Listen          Upstream        Name  Enabled Toxics
@@ -511,7 +511,7 @@ OK
 ```
 
 ```bash
-$ toxiproxy-cli toxic add redis -t latency -a latency=1000
+$ toxiproxy-cli toxic add -t latency -a latency=1000 redis
 Added downstream latency toxic 'latency_downstream' on proxy 'redis'
 ```
 
@@ -526,7 +526,7 @@ $ redis-cli -p 26379
 ```
 
 ```bash
-$ toxiproxy-cli toxic remove redis -n latency_downstream
+$ toxiproxy-cli toxic remove -n latency_downstream redis
 Removed toxic 'latency_downstream' on proxy 'redis'
 ```
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	toxiproxyServer "github.com/Shopify/toxiproxy"
-	"github.com/Shopify/toxiproxy/client"
+	toxiproxy "github.com/Shopify/toxiproxy/client"
 	"github.com/urfave/cli/v2"
 	terminal "golang.org/x/term"
 )
@@ -33,38 +33,38 @@ func color(color string) string {
 }
 
 var toxicDescription = `
-	Default Toxics:
-	latency:	delay all data +/- jitter
-		latency=<ms>,jitter=<ms>
+  Default Toxics:
+  latency:    delay all data +/- jitter
+              latency=<ms>,jitter=<ms>
 
-	bandwidth:	limit to max kb/s
-		rate=<KB/s>
+  bandwidth:  limit to max kb/s
+              rate=<KB/s>
 
-	slow_close:	delay from closing
-		delay=<ms>
+  slow_close: delay from closing
+              delay=<ms>
 
-	timeout: 	stop all data and close after timeout
-	         	timeout=<ms>
+  timeout:    stop all data and close after timeout
+              timeout=<ms>
 
-	slicer: 	slice data into bits with optional delay
-	        	average_size=<bytes>,size_variation=<bytes>,delay=<microseconds>
+  slicer:     slice data into bits with optional delay
+              average_size=<bytes>,size_variation=<bytes>,delay=<microseconds>
 
-	toxic add:
-		usage: toxiproxy-cli toxic add <proxyName> --type <toxicType> --toxicName <toxicName> \
-		--attribute <key=value> --upstream --downstream
+  toxic add:
+    usage: toxiproxy-cli toxic add --type <toxicType> --toxicName <toxicName> \
+            --attribute <key=value> --upstream --downstream <proxyName>
 
-		example: toxiproxy-cli toxic add myProxy -t latency -n myToxic -a latency=100 -a jitter=50
+    example: toxiproxy-cli toxic add -t latency -n myToxic -a latency=100 -a jitter=50 myProxy
 
-	toxic update:
-		usage: toxiproxy-cli toxic update <proxyName> --toxicName <toxicName> \
-		--attribute <key1=value1> --attribute <key2=value2>
+  toxic update:
+    usage: toxiproxy-cli toxic update --toxicName <toxicName> \
+             --attribute <key1=value1> --attribute <key2=value2> <proxyName>
 
-		example: toxiproxy-cli toxic update myProxy -n myToxic -a jitter=25
+    example: toxiproxy-cli toxic update -n myToxic -a jitter=25 myProxy
 
-	toxic delete:
-		usage: toxiproxy-cli toxic delete <proxyName> --toxicName <toxicName>
+  toxic delete:
+    usage: toxiproxy-cli toxic delete --toxicName <toxicName> <proxyName>
 
-		example: toxiproxy-cli toxic delete myProxy -n myToxic
+    example: toxiproxy-cli toxic delete -n myToxic myProxy
 `
 
 var (
@@ -92,7 +92,7 @@ func main() {
 		},
 		{
 			Name:    "create",
-			Usage:   "create a new proxy\n\tusage: 'toxiproxy-cli create <proxyName> --listen <addr> --upstream <addr>'\n",
+			Usage:   "create a new proxy\n\tusage: 'toxiproxy-cli create --listen <addr> --upstream <addr> <proxyName>'\n",
 			Aliases: []string{"c", "new"},
 			Flags: []cli.Flag{
 				&cli.StringFlag{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/toxiproxy
 
-go 1.15
+go 1.17
 
 require (
 	github.com/gorilla/mux v1.8.0
@@ -8,4 +8,11 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
+)
+
+require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
 )

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -138,7 +138,7 @@ func TestProxyToDownUpstream(t *testing.T) {
 
 	conn := AssertProxyUp(t, proxy.Listen, true)
 	// Check to make sure the connection is closed
-	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
 	_, err := conn.Read(make([]byte, 1))
 	if err != io.EOF {
 		t.Error("Proxy did not close connection when upstream down", err)


### PR DESCRIPTION
In #294 introduced a breaking change in client argument parsing.
It requires to write [flags before arguments](https://github.com/urfave/cli/blob/master/docs/migrate-v1-to-v2.md#flags-before-args).
Update help texts and documentation to have POSIX way to use
flags and arguments.

Example:

Before
```shell
$ toxiproxy-cli create shopify_test_redis_master -l localhost:26379 -u localhost:6379
```

After 
```shell
$ toxiproxy-cli create -l localhost:26379 -u localhost:6379 shopify_test_redis_master
```
