### PR TITLE
chore: add /v2 suffix to module import path

### DIFF
--- a/api.go
+++ b/api.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )

--- a/api_test.go
+++ b/api_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy"
-	tclient "github.com/Shopify/toxiproxy/client"
+	"github.com/Shopify/toxiproxy/v2"
+	tclient "github.com/Shopify/toxiproxy/v2/client"
 )
 
 var testServer *toxiproxy.ApiServer

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	toxiproxyServer "github.com/Shopify/toxiproxy"
-	toxiproxy "github.com/Shopify/toxiproxy/client"
+	toxiproxyServer "github.com/Shopify/toxiproxy/v2"
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 	"github.com/urfave/cli/v2"
 	terminal "golang.org/x/term"
 )

--- a/cmd/toxiproxy.go
+++ b/cmd/toxiproxy.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Shopify/toxiproxy"
+	"github.com/Shopify/toxiproxy/v2"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Shopify/toxiproxy
+module github.com/Shopify/toxiproxy/v2
 
 go 1.17
 

--- a/link.go
+++ b/link.go
@@ -3,8 +3,8 @@ package toxiproxy
 import (
 	"io"
 
-	"github.com/Shopify/toxiproxy/stream"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/stream"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 	"github.com/sirupsen/logrus"
 )
 

--- a/link_test.go
+++ b/link_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy/stream"
-	"github.com/Shopify/toxiproxy/testhelper"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/stream"
+	"github.com/Shopify/toxiproxy/v2/testhelper"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 func TestToxicsAreLoaded(t *testing.T) {

--- a/proxy.go
+++ b/proxy.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"sync"
 
-	"github.com/Shopify/toxiproxy/stream"
+	"github.com/Shopify/toxiproxy/v2/stream"
 	"github.com/sirupsen/logrus"
 	tomb "gopkg.in/tomb.v1"
 )

--- a/proxy_collection_test.go
+++ b/proxy_collection_test.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/Shopify/toxiproxy"
+	"github.com/Shopify/toxiproxy/v2"
 )
 
 func TestAddProxyToCollection(t *testing.T) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy"
+	"github.com/Shopify/toxiproxy/v2"
 	"github.com/sirupsen/logrus"
 	tomb "gopkg.in/tomb.v1"
 )

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Shopify/toxiproxy/stream"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/stream"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 // ToxicCollection contains a list of toxics that are chained together. Each proxy

--- a/toxics/bandwidth.go
+++ b/toxics/bandwidth.go
@@ -3,7 +3,7 @@ package toxics
 import (
 	"time"
 
-	"github.com/Shopify/toxiproxy/stream"
+	"github.com/Shopify/toxiproxy/v2/stream"
 )
 
 // The BandwidthToxic passes data through at a limited rate

--- a/toxics/bandwidth_test.go
+++ b/toxics/bandwidth_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 func TestBandwidthToxic(t *testing.T) {

--- a/toxics/latency_test.go
+++ b/toxics/latency_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 func AssertDeltaTime(t *testing.T, message string, actual, expected, delta time.Duration) {

--- a/toxics/limit_data.go
+++ b/toxics/limit_data.go
@@ -1,6 +1,6 @@
 package toxics
 
-import "github.com/Shopify/toxiproxy/stream"
+import "github.com/Shopify/toxiproxy/v2/stream"
 
 // LimitDataToxic has limit in bytes
 type LimitDataToxic struct {

--- a/toxics/limit_data_test.go
+++ b/toxics/limit_data_test.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Shopify/toxiproxy/stream"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/stream"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 func buffer(size int) []byte {

--- a/toxics/slicer.go
+++ b/toxics/slicer.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/Shopify/toxiproxy/stream"
+	"github.com/Shopify/toxiproxy/v2/stream"
 )
 
 // The SlicerToxic slices data into multiple smaller packets

--- a/toxics/slicer_test.go
+++ b/toxics/slicer_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy/stream"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2/stream"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 func TestSlicerToxic(t *testing.T) {

--- a/toxics/timeout_test.go
+++ b/toxics/timeout_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy"
-	"github.com/Shopify/toxiproxy/testhelper"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2"
+	"github.com/Shopify/toxiproxy/v2/testhelper"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
 func WithEstablishedProxy(t *testing.T, f func(net.Conn, net.Conn, *toxiproxy.Proxy)) {

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/Shopify/toxiproxy/stream"
+	"github.com/Shopify/toxiproxy/v2/stream"
 )
 
 // A Toxic is something that can be attatched to a link to modify the way

--- a/toxics/toxic_test.go
+++ b/toxics/toxic_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Shopify/toxiproxy"
-	"github.com/Shopify/toxiproxy/toxics"
+	"github.com/Shopify/toxiproxy/v2"
+	"github.com/Shopify/toxiproxy/v2/toxics"
 	"github.com/sirupsen/logrus"
 	tomb "gopkg.in/tomb.v1"
 )


### PR DESCRIPTION
Since https://github.com/Shopify/toxiproxy/pull/253 added a `go.mod` for
toxiproxy, the v2.x.x release from v2.1.5 can no longer be referred to
as an `+incompatible` module dependency and is required to have a `/v2`
suffix on the module path.

```
server response: not found: github.com/Shopify/toxiproxy@v2.1.5+incompatible:
  invalid version: +incompatible suffix not allowed:
    module contains a go.mod file, so semantic import versioning is required
```
(see [Go Modules have a v2+ Problem](https://donatstudios.com/Go-v2-Modules) for further discussion)

Fixes #310