### PR TITLE
Setup linting

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -2,13 +2,30 @@ name: Analysis
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   schedule:
     - cron: '13 7 * * 6'
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      -
+        name: golangci-lint
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018
+        with:
+          version: v1.42.1
+
+
   vulnerabilities:
     runs-on: ubuntu-latest
 
@@ -17,15 +34,17 @@ jobs:
 
     steps:
       -
-        name: Checkout repository
+        name: checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       -
-        name: Initialize
+        name: initialize
         uses: github/codeql-action/init@v1
         with:
           languages: go
 
       -
-        name: Perform CodeQL Analysis
+        name: codeql analyze
         uses: github/codeql-action/analyze@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+linters:
+  disable-all: true
+  enable:
+    - lll
+    - misspell
+
+linters-settings:
+  lll:
+    line-length: 200

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   Update usage help text and documentation. (#308, @miry)
 * Run e2e tests to validate the command line and basic features of server, client and application (#309, @miry)
 * Add /v2 suffix to module import path (#311, @dnwe)
+* Setup code linter (#314, @miry)
 
 # [2.1.5]
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ all: setup build
 test:
 	go test -v -race ./...
 
+.PHONY: lint
+lint:
+	golangci-lint run
+
 .PHONY: e2e
 e2e: build
 	bin/e2e

--- a/dev.yml
+++ b/dev.yml
@@ -6,6 +6,7 @@ up:
   - homebrew:
       - gnu-tar
       - goreleaser
+      - golangci-lint
   - go:
       version: 1.17
       modules: true


### PR DESCRIPTION
Setup a very basic linting tool [golangci-lint](https://golangci-lint.run/).
Disable all linters as the goal of this changes setup automation.
The code required be formatted and will be enabled one by one.