### PR TITLE
Read `TOXIPROXY_*` environment variables if they exist as default values for the hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Setup code linter (#314, @miry)
   * Max line length is 100 characters (#316, @miry)
   * Linter to check whether HTTP response body is closed successfully (#317, @miry)
+* `--host` flag uses `TOXIPROXY_URL` if it is set (#319, @maaslalani)
 
 # [2.1.5]
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -218,6 +218,7 @@ func main() {
 			Value:       "http://localhost:8474",
 			Usage:       "toxiproxy host to connect to",
 			Destination: &hostname,
+			EnvVars:     []string{"TOXIPROXY_URL"},
 		},
 	}
 


### PR DESCRIPTION
This PR introduces reading from the `TOXIPROXY_URL` variable ~~(or `TOXIPROXY_HOST` + `TOXIPROXY_PORT`)~~ as defaults rather than needing to pass in the `-h somehost.railgun:8474` each time any command is run.


### No variable exported

This tries to read the normal fallback url and cannot connect since I don't have toxiproxy running on this url.

```
$ go run cli/cli.go list
Failed to retrieve proxies: Get "http://localhost:8474/proxies": dial tcp 127.0.0.1:8474: connect: connection refused
exit status 1
```

### Variable exported

Connects to the correct host without the extra flags, even though it is not `127.0.0.1:8474` since the `TOXIPROXY_URL` is set.

```
$ export TOXIPROXY_URL="http://somehost.railgun:8474"
$ go run cli/cli.go list
Name                    Listen          Upstream                Enabled         Toxics
======================================================================================
mysql                   192.168.64.48:30500     somehost.railgun:3306        enabled         1

Hint: inspect toxics with `toxiproxy-cli inspect <proxyName>`
```