### PR TITLE
Extract client flags specs to seperate methods

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -32,7 +32,7 @@ documentation](http://godoc.org/github.com/Shopify/toxiproxy/client).
 
 First import toxiproxy and create a new client:
 ```go
-import "github.com/Shopify/toxiproxy/client"
+import toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 
 client := toxiproxy.NewClient("localhost:8474")
 ```
@@ -95,7 +95,7 @@ import (
     "testing"
     "time"
 
-    "github.com/Shopify/toxiproxy/client"
+    toxiproxy "github.com/Shopify/toxiproxy/v2/client"
     "github.com/garyburd/redigo/redis"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -167,6 +167,70 @@ func (client *Client) Populate(config []Proxy) ([]*Proxy, error) {
 	return proxies.Proxies, err
 }
 
+// AddToxic creates a toxic to proxy
+func (client *Client) AddToxic(options *ToxicOptions) (*Toxic, error) {
+	proxy, err := client.Proxy(options.ProxyName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve proxy with name `%s`: %v", options.ProxyName, err)
+	}
+
+	toxic, err := proxy.AddToxic(
+		options.ToxicName,
+		options.ToxicType,
+		options.Stream,
+		options.Toxicity,
+		options.Attributes,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to add toxic to proxy %s: %v", options.ProxyName, err)
+	}
+
+	return toxic, nil
+}
+
+// UpdateToxic update a toxic in proxy
+func (client *Client) UpdateToxic(options *ToxicOptions) (*Toxic, error) {
+	proxy, err := client.Proxy(options.ProxyName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve proxy with name `%s`: %v", options.ProxyName, err)
+	}
+
+	toxic, err := proxy.UpdateToxic(
+		options.ToxicName,
+		options.Toxicity,
+		options.Attributes,
+	)
+
+	if err != nil {
+		return nil,
+			fmt.Errorf(
+				"failed to update toxic '%s' of proxy '%s': %v",
+				options.ToxicName, options.ProxyName, err,
+			)
+	}
+
+	return toxic, nil
+}
+
+// RemoveToxic removes toxic from proxy
+func (client *Client) RemoveToxic(options *ToxicOptions) error {
+	proxy, err := client.Proxy(options.ProxyName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve proxy with name `%s`: %v", options.ProxyName, err)
+	}
+
+	err = proxy.RemoveToxic(options.ToxicName)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to remove toxic '%s' from proxy '%s': %v",
+			options.ToxicName, options.ProxyName, err,
+		)
+	}
+
+	return nil
+}
+
 // Save saves changes to a proxy such as its enabled status or upstream port.
 func (proxy *Proxy) Save() error {
 	request, err := json.Marshal(proxy)

--- a/client/toxic_option.go
+++ b/client/toxic_option.go
@@ -1,0 +1,10 @@
+package toxiproxy
+
+type ToxicOptions struct {
+	ProxyName,
+	ToxicName,
+	ToxicType,
+	Stream string
+	Toxicity   float32
+	Attributes Attributes
+}


### PR DESCRIPTION
Make sure the main function is not overhelming,
extract portion of lines to separate methods for better read.

Found that client in `toxic add` supports both: `--upstream` and
`--downstream`. Because it tries to create 2 toxic with single name it
produces the error when tries add `--downstream` toxic, and in same time
creates the `--upstream` toxic.

Update the usage help to  mention about argument `--toxicity <float>`

To remove confusion update the client usage help to support only one in
same time. Return error message in case 2 flags provided.

Introduce a new way to add toxics with client: 
Provide a structure`ToxicOptions` with all required options and pass to `client.AddToxic` to add toxic.