### PR TITLE
fix: The release-test task is always success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Extract common test helpers to own files. (#336, @miry)
 * Client: Allow HTTPS endpoints. (#338, @chen-anders)
 * client.Populate assign client to proxy. (#291, @hellodudu)
+* fix: The release-test task is always success.
+  add: Allow to run release-test on arm machines. (#340, @miry)
 
 # [2.2.0]
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ test:
 
 .PHONY: bench
 bench:
+	# TODO: Investigate why benchmarks require more sockets: ulimit -n 10240
 	go test -bench=. -v *.go
 	go test -bench=. -v toxics/*.go
 
@@ -39,21 +40,7 @@ release-dry:
 
 .PHONY: release-test
 release-test: test bench e2e release-dry
-	version="$(shell git describe --abbrev=0 --tags)"
-
-	docker run -v $(PWD)/dist:/dist --pull always --rm -it ubuntu bash -c "dpkg -i /dist/toxiproxy_*_linux_amd64.deb; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version $(version)\""
-	docker run -v $(PWD)/dist:/dist --pull always --rm -it centos bash -c "yum install -y /dist/toxiproxy_*_linux_amd64.rpm; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version $(version)\""
-	docker run -v $(PWD)/dist:/dist --pull always --rm -it alpine sh -c "apk add --allow-untrusted --no-cache /dist/toxiproxy_*_linux_amd64.apk; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version $(version)\""
-
-	tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep toxiproxy-server
-	tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep toxiproxy-cli
-
-	goreleaser build --rm-dist --single-target --skip-validate --id server
-	./dist/toxiproxy-server-* --help 2>&1 | grep "Usage of ./dist/toxiproxy-server"
-
-	goreleaser build --rm-dist --single-target --skip-validate --id client
-	./dist/toxiproxy-cli-* --version | grep "toxiproxy-cli version $(version)"
-
+	bin/release_test
 
 .PHONY: setup
 setup:

--- a/bin/release_test
+++ b/bin/release_test
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ueo pipefail
+
+VERSION_FULL="$(git describe --abbrev=0 --tags)"
+VERSION=${VERSION_FULL:1}
+ARCH=$(uname -m)
+
+docker run -v $(PWD)/dist:/dist --pull always --rm -it ubuntu bash -c "set -xe; dpkg -i /dist/toxiproxy_*_linux_${ARCH}.deb; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version ; /usr/bin/toxiproxy-cli --version | grep -o -e 'toxiproxy-cli version ${VERSION}'"
+docker run -v $(PWD)/dist:/dist --pull always --rm -it centos bash -c "set -xe; yum install -y /dist/toxiproxy_*_linux_${ARCH}.rpm; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version ${VERSION}\""
+docker run -v $(PWD)/dist:/dist --pull always --rm -it alpine sh -c "set -xe; apk add --allow-untrusted --no-cache /dist/toxiproxy_*_linux_${ARCH}.apk; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version ${VERSION}\""
+
+tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep toxiproxy-server
+tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep toxiproxy-cli
+
+goreleaser build --rm-dist --single-target --skip-validate --id server
+./dist/toxiproxy-server-* --help 2>&1 | grep "Usage of ./dist/toxiproxy-server"
+
+goreleaser build --rm-dist --single-target --skip-validate --id client
+./dist/toxiproxy-cli-* --version | grep "toxiproxy-cli version ${VERSION}"


### PR DESCRIPTION
There is a make task to check binaries correctnes that is always success.
It seems the task release-test always was success, because the variables were not
used in the strings.
Extract code from Makefile to make it easy to run single tests
and in same time to keep using only bash.

Also add posibility to run task on arm machines.