### PR TITLE
Add fix for tests on MacOS 12 with -race flag for go17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased]
 
 * Verify git tag on release (#347, @miry)
+* Fix MacOS 12 tests for go17 with -race flag (#351 @strech)
 
 # [2.3.0] - 2021-12-23
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,16 @@
+OS := $(shell uname -s)
+GO_VERSION := $(shell go version | cut -f3 -d" ")
+GO_MINOR_VERSION := $(shell echo $(GO_VERSION) | cut -f2 -d.)
+GO_PATCH_VERSION := $(shell echo $(GO_VERSION) | cut -f3 -d. | sed "s/^\s*$$/0/")
+MALLOC_ENV := $(shell [ $(OS) = Darwin -a $(GO_MINOR_VERSION) -eq 17 -a $(GO_PATCH_VERSION) -lt 6 ] && echo "MallocNanoZone=0")
+
 .PHONY: all
 all: setup build test bench fmt lint
 
 .PHONY: test
 test:
-	go test -v -race -timeout 1m ./...
+	# NOTE: https://github.com/golang/go/issues/49138
+	$(MALLOC_ENV) go test -v -race -timeout 1m ./...
 
 .PHONY: bench
 bench:


### PR DESCRIPTION
> On macOS 12 a new malloc implementation (nano) is used by default, and apparently it reserves address range 0x600000000000-0x600020000000, which conflicts with the address range that TSAN uses for Go
> https://github.com/golang/go/issues/49138

The fix is already merged in upstream, but yet not released. Change will perform OS and Golang version check and add `MallocNanoZone=0` on MacOS with go17 <= 1.17.5 (I hope that 1.17.6 will include upstream fix)

**Question:** Do we want to include other Go versions? Or we consider 1.17 as the main one on MacOS?