### PR TITLE
Print the server version with command line

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -22,7 +22,7 @@ go run testing/endpoint.go 2>&1 | sed -e 's/^/[web] /' &
 
 echo "=== Starting Toxiproxy"
 
-LOG_LEVEL=debug ./dist/toxiproxy-server  2>&1 | sed -e 's/^/[toxiproxy] /' &
+LOG_LEVEL=debug ./dist/toxiproxy-server 2>&1 | sed -e 's/^/[toxiproxy] /' &
 
 echo "=== Wait when service are available"
 

--- a/bin/release_test
+++ b/bin/release_test
@@ -9,15 +9,18 @@ if [ $ARCH == "x86_64" ]; then
   ARCH="amd64"
 fi
 
-docker run -v $(PWD)/dist:/dist --pull always --rm -it ubuntu bash -c "set -xe; dpkg -i /dist/toxiproxy_*_linux_${ARCH}.deb; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version ; /usr/bin/toxiproxy-cli --version | grep -o -e 'toxiproxy-cli version ${VERSION}'"
-docker run -v $(PWD)/dist:/dist --pull always --rm -it centos bash -c "set -xe; yum install -y /dist/toxiproxy_*_linux_${ARCH}.rpm; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version ${VERSION}\""
-docker run -v $(PWD)/dist:/dist --pull always --rm -it alpine sh -c "set -xe; apk add --allow-untrusted --no-cache /dist/toxiproxy_*_linux_${ARCH}.apk; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-cli --version | grep \"toxiproxy-cli version ${VERSION}\""
+goreleaser release --rm-dist --skip-publish --skip-validate
+docker run -v $(PWD)/dist:/dist --pull always --rm -it ubuntu bash -c "set -xe; dpkg -i /dist/toxiproxy_*_linux_${ARCH}.deb; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-server --version ; /usr/bin/toxiproxy-cli --version ; /usr/bin/toxiproxy-cli --version | grep -o -e 'toxiproxy-cli version ${VERSION}'"
+docker run -v $(PWD)/dist:/dist --pull always --rm -it centos bash -c "set -xe; yum install -y /dist/toxiproxy_*_linux_${ARCH}.rpm; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-server --version ; /usr/bin/toxiproxy-cli --version | grep -o -e  \"toxiproxy-cli version ${VERSION}\""
+docker run -v $(PWD)/dist:/dist --pull always --rm -it alpine sh -c "set -xe; apk add --allow-untrusted --no-cache /dist/toxiproxy_*_linux_${ARCH}.apk; ls -1 /usr/bin/toxiproxy-*; /usr/bin/toxiproxy-server --version ; /usr/bin/toxiproxy-cli --version | grep -o -e  \"toxiproxy-cli version ${VERSION}\""
 
-tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep toxiproxy-server
-tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep toxiproxy-cli
+tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep -o -e toxiproxy-server
+tar -ztvf dist/toxiproxy_*_linux_amd64.tar.gz | grep -o -e toxiproxy-cli
 
 goreleaser build --rm-dist --single-target --skip-validate --id server
-./dist/toxiproxy-server-* --help 2>&1 | grep "Usage of ./dist/toxiproxy-server"
+./dist/toxiproxy-server-* --help 2>&1 | grep -o -e "Usage of ./dist/toxiproxy-server"
+./dist/toxiproxy-server-* --version | grep -o -e "toxiproxy-server version ${VERSION}"
 
 goreleaser build --rm-dist --single-target --skip-validate --id client
-./dist/toxiproxy-cli-* --version | grep "toxiproxy-cli version ${VERSION}"
+./dist/toxiproxy-cli-* --help 2>&1 | grep -o -e "toxiproxy-cli - Simulate network and system conditions"
+./dist/toxiproxy-cli-* --version | grep -o -e "toxiproxy-cli version ${VERSION}"


### PR DESCRIPTION
Add flag `-version` to print the current version and exit.

```shell
$ toxiproxy-server -version
toxiproxy-server version v2.3.0
```

closes: #348