### PR TITLE
[RFC] Don't replace proxy with random port in AddOrReplace

### DIFF
--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"sync"
 )
 
@@ -51,6 +52,16 @@ func (collection *ProxyCollection) AddOrReplace(proxy *Proxy, start bool) error 
 		if existing.Listen == proxy.Listen && existing.Upstream == proxy.Upstream {
 			return nil
 		}
+
+		// this is heavier than using strings.HasSuffix but is safe for ipv6 etc.
+		_, port, err := net.SplitHostPort(proxy.Listen)
+		if err != nil {
+			return err
+		}
+		if port == "0" {
+			return nil
+		}
+
 		existing.Stop()
 	}
 

--- a/proxy_collection_test.go
+++ b/proxy_collection_test.go
@@ -41,6 +41,30 @@ func TestAddTwoProxiesToCollection(t *testing.T) {
 	}
 }
 
+func TestAddOrReplaceProxyToCollectionWithRandomPort(t *testing.T) {
+	collection := toxiproxy.NewProxyCollection()
+	proxy1 := NewTestProxy("test", "localhost:20000")
+	proxy2 := NewTestProxy("test", "localhost:0")
+
+	err := collection.AddOrReplace(proxy1, false)
+	if err != nil {
+		t.Error("Expected to be able to add first proxy to collection")
+	}
+
+	err = collection.AddOrReplace(proxy2, false)
+	if err != nil {
+		t.Error("Expected to be able to add second proxy to collection")
+	}
+
+	proxyByName, err := collection.Get("test")
+	if err != nil {
+		t.Error("Expected to find proxy in collection")
+	}
+	if proxyByName.Listen != proxy1.Listen {
+		t.Error("Expected original `.Listen` to be unchanged")
+	}
+}
+
 func TestListProxies(t *testing.T) {
 	collection := toxiproxy.NewProxyCollection()
 	proxy := NewTestProxy("test", "localhost:20000")


### PR DESCRIPTION
When asking ProxyCollection to `AddOrReplace` a proxy with a random
listening port (`:0`), don't stop and replace an existing one with
the same `name` and `upstream`.