### PR TITLE
Improve server log startup message

### DIFF
--- a/api.go
+++ b/api.go
@@ -81,7 +81,8 @@ func (server *ApiServer) Listen(host string, port string) {
 		"host":    host,
 		"port":    port,
 		"version": Version,
-	}).Info("API HTTP server starting")
+	}).Info("Toxiproxy HTTP server is starting")
+	logrus.Printf("Toxiproxy has started. Verify with `curl %s:%s/version`", host, port)
 
 	err := http.ListenAndServe(net.JoinHostPort(host, port), nil)
 	if err != nil {


### PR DESCRIPTION
Old output
```
dist % ./toxiproxy-server
INFO[0000] API HTTP server starting                      host=localhost port=8474 version=git
```

New output
```
dist % ./toxiproxy-server
INFO[0000] Toxiproxy HTTP server is starting             host=localhost port=8474 version=git
INFO[0000] Toxiproxy has started. Verify with `curl localhost:8474/version`
```

Closes #228