### PR TITLE
Basic Linux alternatives for chaotic tooling tc instead of nc

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ stopping you from creating a client in any other language (see
 ## Why yet another chaotic TCP proxy?
 
 The existing ones we found didn't provide the kind of dynamic API we needed for
-integration and unit testing. Linux tools like `nc` and so on are not
+integration and unit testing. Linux tools like `tc` and so on are not
 cross-platform and require root, which makes them problematic in test,
 development and CI environments.
 


### PR DESCRIPTION
I think there is a spelling error here, `nc` does not have the ability of network emulation, `tc`'s `netem` module does, and `tc/netem` module do require root privileges, which corresponds to the context