### PR TITLE
Use go 1.18

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,6 @@ keep_padding       = true
 [*.{yaml,yml}]
 indent_style       = space
 indent_size        = 2
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ["1.17", "1.16", "1.15", "1.14"]
+        go: ["1.18", "1.17", "1.16", "1.15", "1.14"]
     name: Go ${{ matrix.go }}
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: E2E tests
         run: make test-e2e
@@ -51,5 +51,5 @@ jobs:
         uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b
         with:
           distribution: goreleaser
-          version: v0.184.0
+          version: v1.7.0
           args: build --snapshot --rm-dist --skip-post-hooks --skip-validate

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 ---
-
+run:
+  go: "1.17"
 linters:
   disable-all: true
   enable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased]
 
+* Support go 1.18.
+
 # [2.4.0] - 2022-03-07
 
 * Verify git tag on release (#347, @miry)

--- a/dev.yml
+++ b/dev.yml
@@ -13,5 +13,5 @@ up:
       - shfmt
       - yamllint
   - go:
-      version: 1.17
+      version: 1.18
       modules: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/toxiproxy/v2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gorilla/mux v1.8.0
@@ -21,7 +21,6 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -193,9 +193,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/urfave/cli/v2 v2.4.0 h1:m2pxjjDFgDxSPtO8WSdbndj17Wu2y8vOT86wE/tjr+I=
 github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Add 1.18 to the list of CI as supported version.
Update test to check metrics with tags.