### PR TITLE
Removes old link to the blog post from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,4 +618,4 @@ For example, `shopify_test_redis_master` or `shopify_development_mysql_1`.
 
 See [RELEASE.md](./RELEASE.md)
 
-[blog]: https://shopifyengineering.myshopify.com/blogs/engineering/building-and-testing-resilient-ruby-on-rails-applications
+[blog]: https://shopify.engineering/building-and-testing-resilient-ruby-on-rails-applications


### PR DESCRIPTION
Old link takes to a page that has broken links all around.