### PR TITLE
Support go 1.19

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
 
       -
         name: Build release changelog
@@ -70,7 +70,7 @@ jobs:
         uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef
         with:
           distribution: goreleaser
-          version: v0.184.0
+          version: v1.10.3
           args: release --rm-dist --release-notes=tmp/release_changelog.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,17 +14,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ["1.18", "1.17", "1.16", "1.15", "1.14"]
-    name: Go ${{ matrix.go }}
+        go: ["1.19", "1.18", "1.17", "1.16", "1.15"]
+    name: go ${{ matrix.go }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Setup go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
+
       - name: Tests
         run: make test
 
@@ -42,7 +44,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: E2E tests
         run: make test-e2e
@@ -51,5 +53,5 @@ jobs:
         uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef
         with:
           distribution: goreleaser
-          version: v1.7.0
+          version: v1.10.3
           args: build --snapshot --rm-dist --skip-post-hooks --skip-validate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased]
 
-* Support go 1.18.
+* Support go 1.18, 1.19.
 
 # [2.4.0] - 2022-03-07
 

--- a/dev.yml
+++ b/dev.yml
@@ -13,5 +13,5 @@ up:
       - shfmt
       - yamllint
   - go:
-      version: 1.18
+      version: 1.19
       modules: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/toxiproxy/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gorilla/mux v1.8.0


### PR DESCRIPTION
Update go version and github actions to tests against 1.19.
Drop support of 1.14.