### PR TITLE
Upgrade golangci linter

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
         with:
-          version: v1.43.0
+          version: v1.49.0
 
       - name: shellcheck
         uses: azohra/shell-linter@6bbeaa868df09c34ddc008e6030cfe89c03394a1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,10 @@
 ---
 run:
-  go: "1.17"
+  go: "1.15"
 linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - exhaustive
@@ -22,10 +21,8 @@ linters:
     - lll
     - misspell
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - whitespace
   fast: false
 linters-settings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Unreleased]
 
-* Support go 1.18, 1.19. (@miry)
+* Support go 1.18, 1.19. (#415, @miry)
 * `toxiproxy.NewProxy` now accepts `name`, `listen addr` and `upstream addr`. (#418, @miry)
 * Replace logrus with zerolog. (#413, @miry)
 * Log HTTP requests to API server. (#413, #421, @miry)

--- a/link.go
+++ b/link.go
@@ -15,10 +15,9 @@ import (
 // and removed as they are enabled/disabled. New toxics are always added to the end
 // of the chain.
 //
-//         NoopToxic  LatencyToxic
-//             v           v
-// Input > ToxicStub > ToxicStub > Output.
-//
+// |         NoopToxic  LatencyToxic
+// |             v           v
+// | Input > ToxicStub > ToxicStub > Output.
 type ToxicLink struct {
 	stubs     []*toxics.ToxicStub
 	proxy     *Proxy

--- a/test/e2e/endpoint.go
+++ b/test/e2e/endpoint.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
 )
 
 var (
@@ -41,9 +44,19 @@ func main() {
 		stuff[i] = byte(i % 256)
 	}
 	hex.Encode(out, stuff)
-	http.HandleFunc("/test1", handler1)
-	http.HandleFunc("/test2", handler2)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/test1", handler1)
+	r.HandleFunc("/test2", handler2)
 
 	log.Println("Listening :20002")
-	log.Fatal(http.ListenAndServe(":20002", nil))
+
+	srv := &http.Server{
+		Handler:      r,
+		Addr:         ":20002",
+		WriteTimeout: 3 * time.Second,
+		ReadTimeout:  3 * time.Second,
+	}
+
+	log.Fatal(srv.ListenAndServe())
 }

--- a/toxics/limit_data_test.go
+++ b/toxics/limit_data_test.go
@@ -3,7 +3,6 @@ package toxics_test
 import (
 	"bytes"
 	"crypto/rand"
-	"fmt"
 	"testing"
 
 	"github.com/Shopify/toxiproxy/v2/stream"
@@ -26,7 +25,7 @@ func checkOutgoingChunk(t *testing.T, output chan *stream.StreamChunk, expected 
 
 func checkRemainingChunks(t *testing.T, output chan *stream.StreamChunk) {
 	if len(output) != 0 {
-		t.Error(fmt.Sprintf("There is %d chunks in output channel. 0 is expected.", len(output)))
+		t.Errorf("There is %d chunks in output channel. 0 is expected.", len(output))
 	}
 }
 

--- a/toxics/slicer.go
+++ b/toxics/slicer.go
@@ -23,8 +23,8 @@ type SlicerToxic struct {
 // Returns a list of chunk offsets to slice up a packet of the
 // given total size. For example, for a size of 100, output might be:
 //
-//     []int{0, 18, 18, 43, 43, 67, 67, 77, 77, 100}
-//           ^---^  ^----^  ^----^  ^----^  ^-----^
+// |    []int{0, 18, 18, 43, 43, 67, 67, 77, 77, 100}
+// |          ^---^  ^----^  ^----^  ^----^  ^-----^
 //
 // This tries to get fairly evenly-varying chunks (no tendency
 // to have a small/large chunk at the start/end).


### PR DESCRIPTION
Linter shows warning messages to update config:

```shell
$ golangci-lint run
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
```

Remove those plugins.

Resolve new golangci-linter checks:
- One of the big change: Setup timeouts for HTTP servers.


UPDATE: Do not merge. Need to test issue base on previous versions.
