### PR TITLE
Update toxiproxy.NewProxy signature to support common attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased]
 
-* Support go 1.18, 1.19.
+* Support go 1.18, 1.19. (@miry)
+* `toxiproxy.NewProxy` now accepts `name`, `listen addr` and `upstream addr`. (#418, @miry)
 
 # [2.4.0] - 2022-03-07
 

--- a/api.go
+++ b/api.go
@@ -151,10 +151,7 @@ func (server *ApiServer) ProxyCreate(response http.ResponseWriter, request *http
 		return
 	}
 
-	proxy := NewProxy(server)
-	proxy.Name = input.Name
-	proxy.Listen = input.Listen
-	proxy.Upstream = input.Upstream
+	proxy := NewProxy(server, input.Name, input.Listen, input.Upstream)
 
 	err = server.Collection.Add(proxy, input.Enabled)
 	if apiError(response, err) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -19,10 +19,7 @@ func TestProxyMetricsReceivedSentBytes(t *testing.T) {
 	srv := NewServer(NewMetricsContainer(prometheus.NewRegistry()))
 	srv.Metrics.ProxyMetrics = collectors.NewProxyMetricCollectors()
 
-	proxy := NewProxy(srv)
-	proxy.Name = "test_proxy_metrics_received_sent_bytes"
-	proxy.Listen = "localhost:0"
-	proxy.Upstream = "upstream"
+	proxy := NewProxy(srv, "test_proxy_metrics_received_sent_bytes", "localhost:0", "upstream")
 
 	r := bufio.NewReader(bytes.NewBufferString("hello"))
 	w := &testWriteCloser{

--- a/proxy.go
+++ b/proxy.go
@@ -48,8 +48,11 @@ func (c *ConnectionList) Unlock() {
 
 var ErrProxyAlreadyStarted = errors.New("Proxy already started")
 
-func NewProxy(server *ApiServer) *Proxy {
+func NewProxy(server *ApiServer, name, listen, upstream string) *Proxy {
 	proxy := &Proxy{
+		Name:        name,
+		Listen:      listen,
+		Upstream:    upstream,
 		started:     make(chan error),
 		connections: ConnectionList{list: make(map[string]net.Conn)},
 		apiServer:   server,

--- a/proxy_collection.go
+++ b/proxy_collection.go
@@ -97,10 +97,7 @@ func (collection *ProxyCollection) PopulateJson(
 	proxies := make([]*Proxy, 0, len(input))
 
 	for i := range input {
-		proxy := NewProxy(server)
-		proxy.Name = input[i].Name
-		proxy.Listen = input[i].Listen
-		proxy.Upstream = input[i].Upstream
+		proxy := NewProxy(server, input[i].Name, input[i].Listen, input[i].Upstream)
 
 		err = collection.AddOrReplace(proxy, *input[i].Enabled)
 		if err != nil {

--- a/toxics/toxic_test.go
+++ b/toxics/toxic_test.go
@@ -25,11 +25,7 @@ func init() {
 func NewTestProxy(name, upstream string) *toxiproxy.Proxy {
 	srv := toxiproxy.NewServer(toxiproxy.NewMetricsContainer(prometheus.NewRegistry()))
 	srv.Metrics.ProxyMetrics = collectors.NewProxyMetricCollectors()
-	proxy := toxiproxy.NewProxy(srv)
-
-	proxy.Name = name
-	proxy.Listen = "localhost:0"
-	proxy.Upstream = upstream
+	proxy := toxiproxy.NewProxy(srv, name, "localhost:0", upstream)
 
 	return proxy
 }

--- a/toxiproxy_test.go
+++ b/toxiproxy_test.go
@@ -13,11 +13,7 @@ import (
 func NewTestProxy(name, upstream string) *toxiproxy.Proxy {
 	srv := toxiproxy.NewServer(toxiproxy.NewMetricsContainer(prometheus.NewRegistry()))
 	srv.Metrics.ProxyMetrics = collectors.NewProxyMetricCollectors()
-	proxy := toxiproxy.NewProxy(srv)
-
-	proxy.Name = name
-	proxy.Listen = "localhost:0"
-	proxy.Upstream = upstream
+	proxy := toxiproxy.NewProxy(srv, name, "localhost:0", upstream)
 
 	return proxy
 }


### PR DESCRIPTION
NewProxy always uses 4 lines to initialize name, listen and upstream addresses.
Combine them in single initialization via arguments.