### PR TITLE
Add Timeouthandler for HTTP API server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * `toxiproxy.NewProxy` now accepts `name`, `listen addr` and `upstream addr`. (#418, @miry)
 * Replace logrus with zerolog. (#413, @miry)
 * Log HTTP requests to API server. (#413, @miry)
+* Add TimeoutHandler for the HTTP API server. (#420, @miry)
 
 # [2.4.0] - 2022-03-07
 

--- a/api.go
+++ b/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
@@ -54,9 +55,14 @@ func StopBrowsersMiddleware(h http.Handler) http.Handler {
 	})
 }
 
+func timeoutMiddleware(next http.Handler) http.Handler {
+	return http.TimeoutHandler(next, 5*time.Second, "")
+}
+
 func (server *ApiServer) Listen(host string, port string) {
 	r := mux.NewRouter()
 	r.Use(server.loggingMiddleware)
+	r.Use(timeoutMiddleware)
 
 	r.HandleFunc("/reset", server.ResetState).Methods("POST")
 	r.HandleFunc("/proxies", server.ProxyIndex).Methods("GET")


### PR DESCRIPTION
Introduce TimeoutHandler to return with 503 http status code,
if request processing is more than 5 seconds.