### PR TITLE
Limit test phase of build only for linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,4 +54,6 @@ jobs:
         with:
           distribution: goreleaser
           version: v1.10.3
-          args: build --snapshot --rm-dist --skip-post-hooks --skip-validate
+          args: build --snapshot --rm-dist --skip-post-hooks --skip-validate --single-target
+        env:
+          GOOS: linux


### PR DESCRIPTION
Currently `Test / build` step in test workflow finishes 9 minutes.
Update workflow to run build pahse only for Linux.