### PR TITLE
Add trace logger events for Bandwidth toxic

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/Shopify/toxiproxy/v2"
 	"github.com/Shopify/toxiproxy/v2/collectors"
@@ -68,6 +69,7 @@ func run(cli cliArguments) {
 	}
 
 	logger := setupLogger()
+	log.Logger = logger
 
 	rand.Seed(cli.seed)
 

--- a/scripts/test-e2e
+++ b/scripts/test-e2e
@@ -37,7 +37,7 @@ go run ../test/e2e/endpoint.go 2>&1 | sed -e 's/^/[web] /' &
 
 echo "=== Starting Toxiproxy"
 
-LOG_LEVEL=debug $server -proxy-metrics -runtime-metrics 2>&1 | sed -e 's/^/[toxiproxy] /' &
+LOG_LEVEL=trace $server -proxy-metrics -runtime-metrics 2>&1 | sed -e 's/^/[toxiproxy] /' &
 
 echo "=== Wait when services are available"
 


### PR DESCRIPTION
Add more log events for Trace level to debug bandwidth toxic issues.

# Tophat

Run server
```shell
$ LOG_LEVEL=trace ./dist/toxiproxy-server
```

Create proxy and toxics:
```shell
$ ./dist/toxiproxy-cli create -l ":2001" -u "example.com:80" shopify_http
Created new proxy shopify_http

$ ./dist/toxiproxy-cli toxic add --downstream --type=bandwidth --toxicName="bandwidth_downstream1" shopify_http
Added downstream bandwidth toxic 'bandwidth_downstream1' on proxy 'shopify_http'

$ ./dist/toxiproxy-cli toxic add --upstream --type=bandwidth --toxicName="bandwidth_upstream1" shopify_http
Added upstream bandwidth toxic 'bandwidth_upstream1' on proxy 'shopify_http'
```

Create a connection:

```shell
$ nc localhost 2001
GET /
```

During this time remove a toxic:

```shell
$ ./dist/toxiproxy-cli toxic delete --toxicName bandwidth_upstream1 shopify_http
Removed toxic 'bandwidth_upstream1' on proxy 'shopify_http'
```

Sample server output:

```json
{"level":"trace","component":"BandwidthToxic","method":"Pipe","toxic_type":"bandwidth","addr":"0x140003801c0","caller":"bandwidth.go:52","time":"2022-09-07T10:51:02Z","message":"BandwidthToxic was interrupted during writing data"}
{"level":"trace","component":"BandwidthToxic","method":"Pipe","toxic_type":"bandwidth","addr":"0x140003801c0","caller":"bandwidth.go:52","time":"2022-09-07T10:51:02Z","message":"BandwidthToxic was interrupted during writing data"}
```