### PR TITLE
Add gracefull shutdown to HTTP server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased]
 
+* Gracefull shutdown of HTTP server. (#439, @miry)
+
 # [2.5.0] - 2022-09-10
 
 * Update Release steps. (#369, @neufeldtech)

--- a/api_test.go
+++ b/api_test.go
@@ -42,6 +42,7 @@ func WithServer(t *testing.T, f func(string)) {
 
 	f("http://localhost:8475")
 }
+
 func TestRequestId(t *testing.T) {
 	WithServer(t, func(addr string) {
 		client := http.Client{}

--- a/scripts/test-e2e-hazelcast
+++ b/scripts/test-e2e-hazelcast
@@ -26,8 +26,8 @@ function cleanup() {
     docker kill -s SIGQUIT member-proxy
     docker logs -t member-proxy
   fi
-  docker stop member-proxy member0 member1 member2 &> /dev/null || true
-  docker network rm toxiproxy-e2e &> /dev/null || true
+  docker stop member-proxy member0 member1 member2 &>/dev/null || true
+  docker network rm toxiproxy-e2e &>/dev/null || true
 }
 trap "cleanup" EXIT SIGINT SIGTERM
 


### PR DESCRIPTION
Make sure toxiproxy HTTP server close gracefully connection.
Extract endpoints initialization in separate method Routes.
Update notify signal to handle SIGTERM and SIGINT.