### PR TITLE
Use single http client for cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 * Support PATCH HTTP method for Proxy update(`PATCH /proxies/{proxy}`) and
   Toxic update(`PATCH /proxies/{proxy}/toxics/{toxic}`) endpoints.
   Deprecat POST HTTP method for those endpoints. (@miry)
+* Client does not parse response body in case of errors for Populate.
+  Requires to get current proxies with new command. (#441, @miry)
+* Client specifies `User-Agent` HTTP header for all requests as
+  "toxiproxy-cli/<version> <os>/<runtime>".
+  Specifies client request content type as `application/json`. (#441, @miry)
 
 # [2.5.0] - 2022-09-10
 

--- a/api.go
+++ b/api.go
@@ -243,10 +243,13 @@ func (server *ApiServer) ProxyCreate(response http.ResponseWriter, request *http
 
 func (server *ApiServer) Populate(response http.ResponseWriter, request *http.Request) {
 	proxies, err := server.Collection.PopulateJson(server, request.Body)
+	log := zerolog.Ctx(request.Context())
+	if err != nil {
+		log.Warn().Err(err).Msg("Populate errors")
+	}
 
 	apiErr, ok := err.(*ApiError)
 	if !ok && err != nil {
-		log := zerolog.Ctx(request.Context())
 		log.Warn().Err(err).Msg("Error did not include status code")
 		apiErr = &ApiError{err.Error(), http.StatusInternalServerError}
 	}
@@ -268,7 +271,6 @@ func (server *ApiServer) Populate(response http.ResponseWriter, request *http.Re
 	response.WriteHeader(responseCode)
 	_, err = response.Write(data)
 	if err != nil {
-		log := zerolog.Ctx(request.Context())
 		log.Warn().Err(err).Msg("Populate: Failed to write response to client")
 	}
 }
@@ -474,10 +476,12 @@ func (server *ApiServer) ToxicDelete(response http.ResponseWriter, request *http
 }
 
 func (server *ApiServer) Version(response http.ResponseWriter, request *http.Request) {
-	response.Header().Set("Content-Type", "text/plain;charset=utf-8")
-	_, err := response.Write([]byte(Version))
+	log := zerolog.Ctx(request.Context())
+
+	response.Header().Set("Content-Type", "application/json;charset=utf-8")
+	version := fmt.Sprintf(`{"version": "%s"}\n`, Version)
+	_, err := response.Write([]byte(version))
 	if err != nil {
-		log := zerolog.Ctx(request.Context())
 		log.Warn().Err(err).Msg("Version: Failed to write response to client")
 	}
 }

--- a/client/api_error.go
+++ b/client/api_error.go
@@ -6,9 +6,7 @@
 package toxiproxy
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 type ApiError struct {
@@ -18,17 +16,4 @@ type ApiError struct {
 
 func (err *ApiError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s", err.Status, err.Message)
-}
-
-func checkError(resp *http.Response, expectedCode int, caller string) error {
-	if resp.StatusCode != expectedCode {
-		apiError := new(ApiError)
-		err := json.NewDecoder(resp.Body).Decode(apiError)
-		if err != nil {
-			apiError.Message = fmt.Sprintf("Unexpected response code, expected %d", expectedCode)
-			apiError.Status = resp.StatusCode
-		}
-		return fmt.Errorf("%s: %v", caller, apiError)
-	}
-	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,74 @@
+package toxiproxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+)
+
+func TestClient_Headers(t *testing.T) {
+	t.Parallel()
+
+	expected := "toxiproxy-cli/v1.25.0 (darwin/arm64)"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		ua := r.Header.Get("User-Agent")
+
+		if ua != expected {
+			t.Errorf("User-Agent for %s %s is expected `%s', got: `%s'",
+				r.Method,
+				r.URL,
+				expected,
+				ua)
+		}
+
+		contentType := r.Header.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Content-Type for %s %s is expected `application/json', got: `%s'",
+				r.Method,
+				r.URL,
+				contentType)
+		}
+		w.Write([]byte(`foo`))
+	}))
+	defer server.Close()
+
+	client := toxiproxy.NewClient(server.URL)
+	client.UserAgent = expected
+
+	cases := []struct {
+		name string
+		fn   func(c *toxiproxy.Client)
+	}{
+		{"get version", func(c *toxiproxy.Client) { c.Version() }},
+		{"get proxies", func(c *toxiproxy.Client) { c.Proxies() }},
+		{"create proxy", func(c *toxiproxy.Client) {
+			c.CreateProxy("foo", "example.com:0", "example.com:0")
+		}},
+		{"get proxy", func(c *toxiproxy.Client) { c.Proxy("foo") }},
+		{"post populate", func(c *toxiproxy.Client) {
+			c.Populate([]toxiproxy.Proxy{{}})
+		}},
+		{"create toxic", func(c *toxiproxy.Client) {
+			c.AddToxic(&toxiproxy.ToxicOptions{})
+		}},
+		{"update toxic", func(c *toxiproxy.Client) {
+			c.UpdateToxic(&toxiproxy.ToxicOptions{})
+		}},
+		{"delete toxic", func(c *toxiproxy.Client) {
+			c.RemoveToxic(&toxiproxy.ToxicOptions{})
+		}},
+		{"reset state", func(c *toxiproxy.Client) {
+			c.ResetState()
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fn(client)
+		})
+	}
+}

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -262,6 +263,12 @@ type toxiAction func(*cli.Context, *toxiproxy.Client) error
 func withToxi(f toxiAction) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		toxiproxyClient := toxiproxy.NewClient(hostname)
+		toxiproxyClient.UserAgent = fmt.Sprintf(
+			"toxiproxy-cli/%s (%s/%s)",
+			c.App.Version,
+			runtime.GOOS,
+			runtime.GOARCH,
+		)
 		return f(c, toxiproxyClient)
 	}
 }


### PR DESCRIPTION
Introduce single Client httpClient for all cli requests.
It allows to add request headers in single place.
For example adds `User-Agent` HTTP header for all requests as `"toxiproxy-cli/<version> <os>/<runtime>"`.
Parse response on success or errors.
Set content type as json always.

