### PR TITLE
Update interface of ApiServer.Listen to use addr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Client specifies `User-Agent` HTTP header for all requests as
   "toxiproxy-cli/<version> <os>/<runtime>".
   Specifies client request content type as `application/json`. (#441, @miry)
+* Replace Api.Listen parameters `host` and `port` with single `addr`. (#445, @miry)
 
 # [2.5.0] - 2022-09-10
 

--- a/api.go
+++ b/api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -51,8 +50,7 @@ func NewServer(m *metricsContainer, logger zerolog.Logger) *ApiServer {
 	}
 }
 
-func (server *ApiServer) Listen(host string, port string) error {
-	addr := net.JoinHostPort(host, port)
+func (server *ApiServer) Listen(addr string) error {
 	server.Logger.
 		Info().
 		Str("address", addr).

--- a/api_test.go
+++ b/api_test.go
@@ -34,7 +34,7 @@ func WithServer(t *testing.T, f func(string)) {
 			log,
 		)
 
-		go testServer.Listen("localhost", "8475")
+		go testServer.Listen("localhost:8475")
 
 		// Allow server to start. There's no clean way to know when it listens.
 		time.Sleep(50 * time.Millisecond)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -89,12 +90,13 @@ func run() error {
 		server.PopulateConfig(cli.config)
 	}
 
-	go func(server *toxiproxy.ApiServer, host, port string) {
-		err := server.Listen(host, port)
+	addr := net.JoinHostPort(cli.host, cli.port)
+	go func(server *toxiproxy.ApiServer, addr string) {
+		err := server.Listen(addr)
 		if err != nil {
 			server.Logger.Err(err).Msg("Server finished with error")
 		}
-	}(server, cli.host, cli.port)
+	}(server, addr)
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
Provide addr instead of host and port as separate parameters.

Old:
```go
server.Listen("localhost", "8474")
```

New:
```go
server.Listen("localhost:8474")
```