### PR TITLE
go: document ActiveToxics behaviour in Populate

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -109,6 +109,7 @@ func init() {
         Name:     "redis",
         Listen:   "localhost:26379",
         Upstream: "localhost:6379",
+        // note: you cannot set toxics here via ActiveToxics
     }})
     if err != nil {
         panic(err)

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -16,7 +16,9 @@ type Proxy struct {
 	Upstream string `json:"upstream"` // The upstream address to proxy to
 	Enabled  bool   `json:"enabled"`  // Whether the proxy is enabled
 
-	ActiveToxics Toxics `json:"toxics"` // The toxics active on this proxy
+	// The toxics active on this proxy. Note: you cannot set this
+	// when passing Proxy into Populate()
+	ActiveToxics Toxics `json:"toxics"` 
 
 	client  *Client
 	created bool // True if this proxy exists on the server


### PR DESCRIPTION
Currently ActiveToxics has no effect in Populate calls, see #79. This PR adds docs to the Go client to avoid confusion.