### PR TITLE
Rename trunk branch to `main`

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,12 +1,11 @@
 ---
-
 name: Analysis
 
 on:
   push:
-    branches: [ master ]
+    branches: [main]
   pull_request:
-    branches: [ master ]
+    branches: [main]
   schedule:
     - cron: 13 7 * * 6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,11 @@
 ---
-
 name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Toxiproxy
+
 [![GitHub release](https://img.shields.io/github/release/Shopify/toxiproxy.svg)](https://github.com/Shopify/toxiproxy/releases/latest)
 ![Build Status](https://github.com/Shopify/toxiproxy/actions/workflows/test.yml/badge.svg)
 
@@ -81,16 +82,16 @@ development and CI environments.
 
 ## Clients
 
-* [toxiproxy-ruby](https://github.com/Shopify/toxiproxy-ruby)
-* [toxiproxy-go](https://github.com/Shopify/toxiproxy/tree/master/client)
-* [toxiproxy-python](https://github.com/douglas/toxiproxy-python)
-* [toxiproxy.net](https://github.com/mdevilliers/Toxiproxy.Net)
-* [toxiproxy-php-client](https://github.com/ihsw/toxiproxy-php-client)
-* [toxiproxy-node-client](https://github.com/ihsw/toxiproxy-node-client)
-* [toxiproxy-java](https://github.com/trekawek/toxiproxy-java)
-* [toxiproxy-haskell](https://github.com/jpittis/toxiproxy-haskell)
-* [toxiproxy-rust](https://github.com/itarato/toxiproxy_rust)
-* [toxiproxy-elixir](https://github.com/Jcambass/toxiproxy_ex)
+- [toxiproxy-ruby](https://github.com/Shopify/toxiproxy-ruby)
+- [toxiproxy-go](https://github.com/Shopify/toxiproxy/tree/master/client)
+- [toxiproxy-python](https://github.com/douglas/toxiproxy-python)
+- [toxiproxy.net](https://github.com/mdevilliers/Toxiproxy.Net)
+- [toxiproxy-php-client](https://github.com/ihsw/toxiproxy-php-client)
+- [toxiproxy-node-client](https://github.com/ihsw/toxiproxy-node-client)
+- [toxiproxy-java](https://github.com/trekawek/toxiproxy-java)
+- [toxiproxy-haskell](https://github.com/jpittis/toxiproxy-haskell)
+- [toxiproxy-rust](https://github.com/itarato/toxiproxy_rust)
+- [toxiproxy-elixir](https://github.com/Jcambass/toxiproxy_ex)
 
 ## Example
 
@@ -208,9 +209,9 @@ binaries and system packages for your architecture.
 **Ubuntu**
 
 ```bash
-$ wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
-$ sudo dpkg -i toxiproxy-2.1.4.deb
-$ sudo service toxiproxy start
+wget -O toxiproxy-2.1.4.deb https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy_2.1.4_amd64.deb
+sudo dpkg -i toxiproxy-2.1.4.deb
+sudo service toxiproxy start
 ```
 
 **OS X**
@@ -218,19 +219,19 @@ $ sudo service toxiproxy start
 With [Homebrew](https://brew.sh/):
 
 ```bash
-$ brew tap shopify/shopify
-$ brew install toxiproxy
+brew tap shopify/shopify
+brew install toxiproxy
 ```
 
 Or with [MacPorts](https://www.macports.org/):
 
 ```bash
-$ port install toxiproxy
+port install toxiproxy
 ```
 
 **Windows**
 
-Toxiproxy for Windows is available for download at https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy-server-windows-amd64.exe
+Toxiproxy for Windows is available for download at <https://github.com/Shopify/toxiproxy/releases/download/v2.1.4/toxiproxy-server-windows-amd64.exe>
 
 **Docker**
 
@@ -238,22 +239,23 @@ Toxiproxy is available on [Github container registry](https://github.com/Shopify
 Old versions `<= 2.1.4` are available on on [Docker Hub](https://hub.docker.com/r/shopify/toxiproxy/).
 
 ```bash
-$ docker pull ghcr.io/shopify/toxiproxy
-$ docker run --rm -it ghcr.io/shopify/toxiproxy
+docker pull ghcr.io/shopify/toxiproxy
+docker run --rm -it ghcr.io/shopify/toxiproxy
 ```
 
 If using Toxiproxy from the host rather than other containers, enable host networking with `--net=host`.
 
 ```shell
-$ docker run --rm --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy list
+docker run --rm --entrypoint="/toxiproxy-cli" -it ghcr.io/shopify/toxiproxy list
 ```
 
 **Source**
 
 If you have Go installed, you can build Toxiproxy from source using the make file:
+
 ```bash
-$ make build
-$ ./toxiproxy-server
+make build
+./toxiproxy-server
 ```
 
 #### Upgrading from Toxiproxy 1.x
@@ -385,8 +387,8 @@ Add a delay to all data going through the proxy. The delay is equal to `latency`
 
 Attributes:
 
- - `latency`: time in milliseconds
- - `jitter`: time in milliseconds
+- `latency`: time in milliseconds
+- `jitter`: time in milliseconds
 
 #### down
 
@@ -400,7 +402,7 @@ Limit a connection to a maximum number of kilobytes per second.
 
 Attributes:
 
- - `rate`: rate in KB/s
+- `rate`: rate in KB/s
 
 #### slow_close
 
@@ -408,7 +410,7 @@ Delay the TCP socket from closing until `delay` has elapsed.
 
 Attributes:
 
- - `delay`: time in milliseconds
+- `delay`: time in milliseconds
 
 #### timeout
 
@@ -418,7 +420,7 @@ toxic is removed.
 
 Attributes:
 
- - `timeout`: time in milliseconds
+- `timeout`: time in milliseconds
 
 #### reset_peer
 
@@ -427,7 +429,7 @@ immediately or after a `timeout`.
 
 Attributes:
 
- - `timeout`: time in milliseconds
+- `timeout`: time in milliseconds
 
 #### slicer
 
@@ -436,15 +438,15 @@ sliced "packet".
 
 Attributes:
 
- - `average_size`: size in bytes of an average packet
- - `size_variation`: variation in bytes of an average packet (should be smaller than average_size)
- - `delay`: time in microseconds to delay each packet by
+- `average_size`: size in bytes of an average packet
+- `size_variation`: variation in bytes of an average packet (should be smaller than average_size)
+- `delay`: time in microseconds to delay each packet by
 
 #### limit_data
 
 Closes connection when transmitted data exceeded limit.
 
- - `bytes`: number of bytes it should transmit before connection is closed
+- `bytes`: number of bytes it should transmit before connection is closed
 
 ### HTTP API
 
@@ -453,12 +455,12 @@ HTTP interface, which is described here.
 
 Toxiproxy listens for HTTP on port **8474**.
 
-#### Proxy fields:
+#### Proxy fields
 
- - `name`: proxy name (string)
- - `listen`: listen address (string)
- - `upstream`: proxy upstream address (string)
- - `enabled`: true/false (defaults to true on creation)
+- `name`: proxy name (string)
+- `listen`: listen address (string)
+- `upstream`: proxy upstream address (string)
+- `enabled`: true/false (defaults to true on creation)
 
 To change a proxy's name, it must be deleted and recreated.
 
@@ -470,13 +472,13 @@ in the response will be updated with the actual port.
 If you change `enabled` to `false`, it will take down the proxy. You can switch it
 back to `true` to reenable it.
 
-#### Toxic fields:
+#### Toxic fields
 
- - `name`: toxic name (string, defaults to `<type>_<stream>`)
- - `type`: toxic type (string)
- - `stream`: link direction to affect (defaults to `downstream`)
- - `toxicity`: probability of the toxic being applied to a link (defaults to 1.0, 100%)
- - `attributes`: a map of toxic-specific attributes
+- `name`: toxic name (string, defaults to `<type>_<stream>`)
+- `type`: toxic type (string)
+- `stream`: link direction to affect (defaults to `downstream`)
+- `toxicity`: probability of the toxic being applied to a link (defaults to 1.0, 100%)
+- `attributes`: a map of toxic-specific attributes
 
 See [Toxics](#toxics) for toxic-specific attributes.
 
@@ -489,20 +491,20 @@ separately.
 
 All endpoints are JSON.
 
- - **GET /proxies** - List existing proxies and their toxics
- - **POST /proxies** - Create a new proxy
- - **POST /populate** - Create or replace a list of proxies
- - **GET /proxies/{proxy}** - Show the proxy with all its active toxics
- - **POST /proxies/{proxy}** - Update a proxy's fields
- - **DELETE /proxies/{proxy}** - Delete an existing proxy
- - **GET /proxies/{proxy}/toxics** - List active toxics
- - **POST /proxies/{proxy}/toxics** - Create a new toxic
- - **GET /proxies/{proxy}/toxics/{toxic}** - Get an active toxic's fields
- - **POST /proxies/{proxy}/toxics/{toxic}** - Update an active toxic
- - **DELETE /proxies/{proxy}/toxics/{toxic}** - Remove an active toxic
- - **POST /reset** - Enable all proxies and remove all active toxics
- - **GET /version** - Returns the server version number
- - **GET /metrics** - Returns Prometheus-compatible metrics
+- **GET /proxies** - List existing proxies and their toxics
+- **POST /proxies** - Create a new proxy
+- **POST /populate** - Create or replace a list of proxies
+- **GET /proxies/{proxy}** - Show the proxy with all its active toxics
+- **POST /proxies/{proxy}** - Update a proxy's fields
+- **DELETE /proxies/{proxy}** - Delete an existing proxy
+- **GET /proxies/{proxy}/toxics** - List active toxics
+- **POST /proxies/{proxy}/toxics** - Create a new toxic
+- **GET /proxies/{proxy}/toxics/{toxic}** - Get an active toxic's fields
+- **POST /proxies/{proxy}/toxics/{toxic}** - Update an active toxic
+- **DELETE /proxies/{proxy}/toxics/{toxic}** - Remove an active toxic
+- **POST /reset** - Enable all proxies and remove all active toxics
+- **GET /version** - Returns the server version number
+- **GET /metrics** - Returns Prometheus-compatible metrics
 
 #### Populating Proxies
 
@@ -607,12 +609,12 @@ For example, `shopify_test_redis_master` or `shopify_development_mysql_1`.
 
 ### Development
 
-* `make`. Build a toxiproxy development binary for the current platform.
-* `make all`. Build Toxiproxy binaries and packages for all platforms. Requires
+- `make`. Build a toxiproxy development binary for the current platform.
+- `make all`. Build Toxiproxy binaries and packages for all platforms. Requires
   to have Go compiled with cross compilation enabled on Linux and Darwin (amd64)
   as well as [`goreleaser`](https://goreleaser.com/) in your `$PATH` to
   build binaries the Linux package.
-* `make test`. Run the Toxiproxy tests.
+- `make test`. Run the Toxiproxy tests.
 
 ### Release
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,8 +20,8 @@ Ensure your local workstation is configured to be able to [Sign commits](https:/
 ### Checkout latest code
 
 ```shell
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 ```
 
 ### Update the [CHANGELOG.md](CHANGELOG.md)
@@ -43,9 +43,10 @@ git tag -s "v$RELEASE_VERSION" # When prompted for a commit message, enter the '
 make test-release
 ```
 
-- Push to Master Branch
+- Push to Main Branch
+
 ```shell
-git push origin master --follow-tags
+git push origin main --follow-tags
 ```
 
 ## Push Release Tag
@@ -70,8 +71,10 @@ git push origin "v$RELEASE_VERSION"
 
 - Do a manual check of installing toxiproxy via brew
   1. While in the homebrew-shopify directory...
+
   ```shell
   brew install ./toxiproxy.rb --debug
   ```
+
   Note: it's normal to get some errors when homebrew attempts to load the file as a Cask instead of a formula, just make sure that it still gets installed.
 - PR the version update change and merge


### PR DESCRIPTION
For consistency with other projects, renaming the trunk branch from `master` to `main`. Once the documentation is updated I will make this change for the GH repo as well.