### PR TITLE
Updating golangci-lint version and default trunk name changes

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -4,9 +4,9 @@ name: Analysis
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: 13 7 * * 6
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
         with:
-          version: v1.49.0
+          version: v1.52.2
 
       - name: shellcheck
         uses: azohra/shell-linter@6bbeaa868df09c34ddc008e6030cfe89c03394a1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ development and CI environments.
 ## Clients
 
 * [toxiproxy-ruby](https://github.com/Shopify/toxiproxy-ruby)
-* [toxiproxy-go](https://github.com/Shopify/toxiproxy/tree/master/client)
+* [toxiproxy-go](https://github.com/Shopify/toxiproxy/tree/main/client)
 * [toxiproxy-python](https://github.com/douglas/toxiproxy-python)
 * [toxiproxy.net](https://github.com/mdevilliers/Toxiproxy.Net)
 * [toxiproxy-php-client](https://github.com/ihsw/toxiproxy-php-client)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,8 +20,8 @@ Ensure your local workstation is configured to be able to [Sign commits](https:/
 ### Checkout latest code
 
 ```shell
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 ```
 
 ### Update the [CHANGELOG.md](CHANGELOG.md)
@@ -43,9 +43,9 @@ git tag -s "v$RELEASE_VERSION" # When prompted for a commit message, enter the '
 make test-release
 ```
 
-- Push to Master Branch
+- Push to Main Branch
 ```shell
-git push origin master --follow-tags
+git push origin main --follow-tags
 ```
 
 ## Push Release Tag


### PR DESCRIPTION
Merging the master changes to main to replace branch name to make it more inclusive.
This change involves replacing the usages of master to main from readme, release.md and GH actions

Builds are failing due to version mismatch between golangci-lint-action and golangci-lint. So the `golangci-lint` version is also updated
