### PR TITLE
Revert trunk name changes on GH actions and readmes for master

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -4,9 +4,9 @@ name: Analysis
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
   schedule:
     - cron: 13 7 * * 6
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ development and CI environments.
 ## Clients
 
 * [toxiproxy-ruby](https://github.com/Shopify/toxiproxy-ruby)
-* [toxiproxy-go](https://github.com/Shopify/toxiproxy/tree/main/client)
+* [toxiproxy-go](https://github.com/Shopify/toxiproxy/tree/master/client)
 * [toxiproxy-python](https://github.com/douglas/toxiproxy-python)
 * [toxiproxy.net](https://github.com/mdevilliers/Toxiproxy.Net)
 * [toxiproxy-php-client](https://github.com/ihsw/toxiproxy-php-client)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,8 +20,8 @@ Ensure your local workstation is configured to be able to [Sign commits](https:/
 ### Checkout latest code
 
 ```shell
-git checkout main
-git pull origin main
+git checkout master
+git pull origin master
 ```
 
 ### Update the [CHANGELOG.md](CHANGELOG.md)
@@ -43,9 +43,9 @@ git tag -s "v$RELEASE_VERSION" # When prompted for a commit message, enter the '
 make test-release
 ```
 
-- Push to Main Branch
+- Push to Master Branch
 ```shell
-git push origin main --follow-tags
+git push origin master --follow-tags
 ```
 
 ## Push Release Tag


### PR DESCRIPTION
These changes should be only on `main` branch and not on `master` branch which got merged accidentally.

On this repo, the default branch is now `main` and the GH actions are updated on `main`
This PR will leave `master` branch untouched w.r.t trunk name changes.
Once changes are verified, the `master` branch will be cleaned off.