### PR TITLE
sortedAttributes sort by Key instead of value

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -619,16 +619,15 @@ type attribute struct {
 
 type attributeList []attribute
 
-func (a attributeList) Len() int           { return len(a) }
-func (a attributeList) Less(i, j int) bool { return a[i].key < a[j].key }
-func (a attributeList) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-
 func sortedAttributes(attrs toxiproxy.Attributes) attributeList {
 	li := make(attributeList, 0, len(attrs))
 	for k, v := range attrs {
-		li = append(li, attribute{k, v.(float64)})
+		li = append(li, attribute{k, v})
 	}
-	sort.Sort(li)
+	sort.Slice(li, func(i, j int) bool {
+		return li[i].key < li[j].key
+	})
+
 	return li
 }
 


### PR DESCRIPTION
## Summary

When "inspecting" a toxic via toxiproxy-cli (eg: `toxiproxy-cli inspect mysql`), `sortedAttributes` fails to handle non float types. This function is only used when rendering to the console. 

To work around, this sort via the `attribute.key` instead of the `attribute.value`.


```sh
 » toxiproxy-cli inspect mysql
Name: mysql	Listen: [::]:4306	Upstream: yahoo.ca:80
======================================================================
Upstream toxics:
debug_upstream:	type=debug	stream=upstream	toxicity=1.00	attributes=[panic: interface conversion: interface {} is string, not float64

goroutine 1 [running]:
main.sortedAttributes(0x140000204b0)
	/Users/jesseward/code/toxiproxy/cmd/cli/cli.go:629 +0x1e4
main.listToxics({0x14000082180?, 0x1, 0x10243d486?}, {0x10241e65b?, 0x8?})
	/Users/jesseward/code/toxiproxy/cmd/cli/cli.go:653 +0x440
main.inspectProxy(0x140001ce300, 0x18?)
	/Users/jesseward/code/toxiproxy/cmd/cli/cli.go:364 +0x728
main.cliCommands.withToxi.func2(0x140001ce300)
	/Users/jesseward/code/toxiproxy/cmd/cli/cli.go:272 +0xec
github.com/urfave/cli/v2.(*Command).Run(0x140001cc580, 0x140001ce300, {0x140001a86e0, 0x2, 0x2})
	/Users/jesseward/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x730
github.com/urfave/cli/v2.(*Command).Run(0x140001ccdc0, 0x140001ce140, {0x1400012c180, 0x3, 0x3})
	/Users/jesseward/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267 +0x940
github.com/urfave/cli/v2.(*App).RunContext(0x140001c6000, {0x1025c8e98?, 0x102923580}, {0x1400012c180, 0x3, 0x3})
	/Users/jesseward/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x518
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/jesseward/go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:309
main.main()
	/Users/jesseward/code/toxiproxy/cmd/cli/cli.go:104 +0x358
```
## Testing

Create a toxic with an int-ish type and a string 

```sh
dist/toxiproxy-server & ; dist/toxiproxy-cli create -l :4306 -u yahoo.ca:80 mysql && \
dist/toxiproxy-cli toxic add -u -a number=1 -a a_string=yahoo -t debug mysql
```

update `_examples/toxics/debug_toxic.go` to include

```go
// DebugToxic prints bytes processed through pipe.
type DebugToxic struct {
	Number  int    `json:"number"`
	AString string `json:"a_string"`
}
```

```sh
» go run cmd/cli/cli.go inspect mysql                                                                                                       jesseward@Jesses-MacBook-Pro
Name: mysql     Listen: [::]:4306       Upstream: yahoo.ca:80
======================================================================
Upstream toxics:
debug_upstream: type=debug      stream=upstream toxicity=1.00   attributes=[    a_string=yahoo  number=1        ]

Downstream toxics:
Proxy has no Downstream toxics enabled.

Hint: add a toxic with `toxiproxy-cli toxic add`
```