### PR TITLE
Use packages instead of homebrew

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,7 +5,7 @@ name: toxiproxy
 type: go
 
 up:
-  - homebrew:
+  - packages:
       - gnu-tar
       - golangci-lint
       - goreleaser


### PR DESCRIPTION
dev.yml is deprecating `homebrew` in favor of `packages` directive
