### PR TITLE
Do not pin minimum patch version in module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/toxiproxy/v2
 
-go 1.22.8
+go 1.22
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
Specifying the patch version in the Go module means that any other modules using this need to comply. This has caused our `go.mod` file to change. While is not necessarily bad, we only use this library for testing so it feels wrong to have to pin our own version to match this module.

By only specifying the major+minor version in the `go.mod` file, we let the Go toolchain pick the appropriate version that is available when building the binary but requiring at least the `1.22` version.