### PR TITLE
Update README.md - clarify timeout toxic behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Attributes:
 #### timeout
 
 Stops all data from getting through, and closes the connection after `timeout`. If
-`timeout` is 0, the connection won't close, and data will be delayed until the
+`timeout` is 0, the connection won't close, and data will be dropped until the
 toxic is removed.
 
 Attributes:


### PR DESCRIPTION
The code for the timeout toxic when timeout is set to zero simply reads from the input and then if it gets some data just has a comment: "// Drop the data on the ground".  This change updates the docs do indicate the data is dropped, not delayed, until the texic is removed.