### PR TITLE
Fixes some linter errors to fix workflow error

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -21,9 +21,9 @@ jobs:
           fetch-depth: 0
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8
+        uses: golangci/golangci-lint-action@eab1d2f3d76f26c09e2ab8c957fe5bb64bf46b89
         with:
-          version: v1.56.2
+          version: v1.62.2
 
       - name: shellcheck
         uses: azohra/shell-linter@6bbeaa868df09c34ddc008e6030cfe89c03394a1

--- a/link_test.go
+++ b/link_test.go
@@ -157,9 +157,9 @@ func TestNoDataDropped(t *testing.T) {
 	done := make(chan struct{})
 	defer close(done)
 	go func() {
-		for i := 0; i < 64*1024; i++ {
+		for i := uint16(0); i < 65535; i++ {
 			buf := make([]byte, 2)
-			binary.BigEndian.PutUint16(buf, uint16(i))
+			binary.BigEndian.PutUint16(buf, i)
 			link.input.Write(buf)
 		}
 		link.input.Close()
@@ -177,13 +177,13 @@ func TestNoDataDropped(t *testing.T) {
 	}(ctx)
 
 	buf := make([]byte, 2)
-	for i := 0; i < 64*1024; i++ {
+	for i := uint16(0); i < 65535; i++ {
 		n, err := link.output.Read(buf)
 		if n != 2 || err != nil {
 			t.Fatalf("Read failed: %d %v", n, err)
 		} else {
 			val := binary.BigEndian.Uint16(buf)
-			if val != uint16(i) {
+			if val != i {
 				t.Fatalf("Read incorrect bytes: %v != %d", val, i)
 			}
 		}


### PR DESCRIPTION
The linter CI job is failing per the error in this job: https://github.com/Shopify/toxiproxy/actions/runs/11640869223/job/32418715356

It fails on the linter, however there is no logs around why it fails. I've fixed the linter errors on main (there were 2) as well as incremented the version of the linter to 1.62.2 and that seems to have resolved the issue.

How to 🎩 :

1. Do a `golangci-lint run` and verify it succeeds (no errors should print).