### PR TITLE
Update client readme example to compile with previous API changes

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -20,7 +20,7 @@ client api has changed:
     down a proxy.
  - `proxy.ToxicsUpstream` and `proxy.ToxicsDownstream` have been merged into a
     single `ActiveToxics` list.
- - `proxy.Toxics()`` no longer requires a direction to be specified, and will
+ - `proxy.Toxics()` no longer requires a direction to be specified, and will
     return toxics for both directions.
  - `proxy.SetToxic()` has been replaced by `proxy.AddToxic()`,
    `proxy.UpdateToxic()`, and `proxy.RemoveToxic()`.
@@ -91,7 +91,6 @@ proxy.Delete()
 
 ```go
 import (
-    "net/http"
     "testing"
     "time"
 


### PR DESCRIPTION
Updates the full example in the client readme to compile. It was broken and didn't reflect the current API. I also removed an unnecessary example test that wasn't necessary to get a feel for how to use Toxiproxy.