### PR TITLE
fix(toxics/slicer): clamp jittered mid within [start, end] to avoid reversed-slice panic

### DIFF
--- a/toxics/slicer.go
+++ b/toxics/slicer.go
@@ -42,6 +42,18 @@ func (t *SlicerToxic) chunk(start int, end int) []int {
 	if t.SizeVariation > 0 {
 		mid += rand.Intn(t.SizeVariation*2) - t.SizeVariation // #nosec G404 -- was ignored before too
 	}
+	// rand.Intn returns [0, SizeVariation*2), so mid can jitter into
+	// [base-SizeVariation, base+SizeVariation). When SizeVariation is
+	// large relative to (end-start), mid can land before start or
+	// after end, and Pipe later slices c.Data[chunks[i-1]:chunks[i]]
+	// with a reversed range - panicking 'slice bounds out of range
+	// [X:Y]' (#541). Clamp mid to [start, end] so every output chunk
+	// stays in monotonic order.
+	if mid < start {
+		mid = start
+	} else if mid > end {
+		mid = end
+	}
 	left := t.chunk(start, mid)
 	right := t.chunk(mid, end)
 


### PR DESCRIPTION
## What

Fixes #541.

`SlicerToxic.chunk` jitters the split point with:

```go
mid += rand.Intn(SizeVariation*2) - SizeVariation
```

so `mid` can land in `[base-SizeVariation, base+SizeVariation)`. When `SizeVariation` is large relative to `(end-start)`, `mid` can fall below `start` or above `end`. `Pipe` later slices `c.Data[chunks[i-1]:chunks[i]]` with a reversed range and the runtime panics:

```
panic: runtime error: slice bounds out of range [808:773]
```

taking down the toxic's goroutine and with it the pipeline.

## Fix

Clamp `mid` to `[start, end]` after the jitter so the chunk boundaries stay monotonic. The jitter distribution is otherwise preserved: if `mid` is inside the range, no change; if it would go out of bounds, it is pinned to the nearest valid endpoint.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l toxics/slicer.go`: clean
- `go vet ./...`: clean
- `go test -race -count=1 ./toxics/...`: pass

Closes #541