### PR TITLE
cache hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           go-version: 1.22
           check-latest: true
-          cache: true
+          cache: false
       -
         name: Build release changelog
         run: |


### PR DESCRIPTION
Disables the Go module cache on the release workflow (`cache: false` on `actions/setup-go`) so the release build does not restore a cache populated by other workflow runs.