### PR TITLE
docs: clarify that latency toxics are one-way

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,12 @@ For documentation on implementing custom toxics, see [CREATING_TOXICS.md](./CREA
 
 #### latency
 
-Add a delay to all data going through the proxy. The delay is equal to `latency` +/- `jitter`.
+Add a delay to data on a single proxy stream. The delay is equal to `latency` +/- `jitter`.
+
+Toxics are directional: by default a latency toxic is attached to the `downstream`
+stream (`server -> client`). It does not delay the opposite direction unless you
+also add a latency toxic with `stream=upstream`. For a symmetric round-trip delay,
+add latency on both streams.
 
 Attributes:
 


### PR DESCRIPTION
## Summary
- The latency toxic docs said the delay applied to all data through the proxy, which read like a bidirectional round trip.
- Latency toxics only affect the stream they are attached to (default `downstream`). Symmetric delay needs latency on both `upstream` and `downstream`.
- Updates the latency section to match the existing stream field behavior.

Fixes #655

## Test plan
- [ ] Read the latency section in README and confirm it matches the `stream` field docs
- [ ] No code changes; docs only