### PR TITLE
fix: bound and short-circuit the ToxicDelete deadlock on dead sinks

### DIFF
--- a/link.go
+++ b/link.go
@@ -29,6 +29,9 @@ type ToxicLink struct {
 	output    *stream.ChanReader
 	direction stream.Direction
 	Logger    *zerolog.Logger
+
+	// writeDone closes when write stops draining link.output; see ToxicStub.OutputDone.
+	writeDone chan struct{}
 }
 
 func NewToxicLink(
@@ -47,6 +50,7 @@ func NewToxicLink(
 		toxics:    collection,
 		direction: direction,
 		Logger:    &logger,
+		writeDone: make(chan struct{}),
 	}
 	// Initialize the link with ToxicStubs
 	last := make(chan *stream.StreamChunk) // The first toxic is always a noop
@@ -62,8 +66,20 @@ func NewToxicLink(
 		link.stubs[i] = toxics.NewToxicStub(last, next)
 		last = next
 	}
+	for i := 0; i < len(link.stubs)-1; i++ {
+		link.stubs[i].OutputDone = link.stubs[i+1].Done()
+	}
+	link.stubs[len(link.stubs)-1].OutputDone = link.writeDone
 	link.output = stream.NewChanReader(last)
+	link.setOutputTimeout(collection.outputTimeout(direction))
 	return link
+}
+
+// setOutputTimeout updates every stub's send timeout for this link.
+func (link *ToxicLink) setOutputTimeout(d time.Duration) {
+	for _, stub := range link.stubs {
+		stub.SetTimeout(d)
+	}
 }
 
 // Start the link with the specified toxics.
@@ -149,6 +165,8 @@ func (link *ToxicLink) write(
 		Str("link_addr", fmt.Sprintf("%p", link)).
 		Logger()
 
+	defer close(link.writeDone)
+
 	bytes, err := io.Copy(dest, link.output)
 	if err != nil {
 		logger.Warn().
@@ -177,6 +195,8 @@ func (link *ToxicLink) AddToxic(toxic *toxics.ToxicWrapper) {
 	// Interrupt the last toxic so that we don't have a race when moving channels
 	if link.stubs[i-1].InterruptToxic() {
 		link.stubs[i-1].Output = newin
+		link.stubs[i-1].OutputDone = link.stubs[i].Done()
+		link.stubs[i].OutputDone = link.writeDone
 
 		if stateful, ok := toxic.Toxic.(toxics.StatefulToxic); ok {
 			link.stubs[i].State = stateful.NewState()
@@ -233,8 +253,10 @@ func (link *ToxicLink) RemoveToxic(ctx context.Context, toxic *toxics.ToxicWrapp
 
 		// Unblock the previous toxic if it is trying to flush
 		// If the previous toxic is closed, continue flusing until we reach the end.
+		// sinkDead: once one send times out, don't retry the rest item by item.
 		interrupted := false
 		stopped := false
+		sinkDead := false
 		for !interrupted {
 			select {
 			case interrupted = <-stop:
@@ -248,8 +270,12 @@ func (link *ToxicLink) RemoveToxic(ctx context.Context, toxic *toxics.ToxicWrapp
 					return // TODO: There are some steps after this to clean buffer
 				}
 
-				err := link.stubs[toxic_index].WriteOutput(tmp, 5*time.Second)
+				if sinkDead {
+					continue
+				}
+				err := link.stubs[toxic_index].WriteOutput(tmp, link.stubs[toxic_index].Timeout())
 				if err != nil {
+					sinkDead = true
 					log.Err(err).
 						Msg("Could not write last packets after interrupt to Output")
 				}
@@ -257,24 +283,41 @@ func (link *ToxicLink) RemoveToxic(ctx context.Context, toxic *toxics.ToxicWrapp
 		}
 
 		// Empty the toxic's buffer if necessary
-		for len(link.stubs[toxic_index].Input) > 0 {
-			tmp := <-link.stubs[toxic_index].Input
-			if tmp == nil {
-				link.stubs[toxic_index].Close()
-				return
-			}
-			err := link.stubs[toxic_index].WriteOutput(tmp, 5*time.Second)
-			if err != nil {
-				log.Err(err).
-					Msg("Could not write last packets after interrupt to Output")
-			}
+		if !link.drainBufferedInput(log, link.stubs[toxic_index], sinkDead) {
+			return
 		}
 
 		link.stubs[toxic_index-1].Output = link.stubs[toxic_index].Output
+		link.stubs[toxic_index-1].OutputDone = link.stubs[toxic_index].OutputDone
 		link.stubs = append(link.stubs[:toxic_index], link.stubs[toxic_index+1:]...)
 
 		go link.stubs[toxic_index-1].Run(link.toxics.chain[link.direction][toxic_index-1])
 	}
+}
+
+// drainBufferedInput flushes whatever is left in stub's Input queue after an
+// interrupt. Returns false if the stub closed itself while draining, in
+// which case RemoveToxic must not touch the stub any further.
+func (link *ToxicLink) drainBufferedInput(
+	log zerolog.Logger,
+	stub *toxics.ToxicStub,
+	sinkDead bool,
+) bool {
+	for len(stub.Input) > 0 {
+		tmp := <-stub.Input
+		if tmp == nil {
+			stub.Close()
+			return false
+		}
+		if sinkDead {
+			continue
+		}
+		if err := stub.WriteOutput(tmp, stub.Timeout()); err != nil {
+			sinkDead = true
+			log.Err(err).Msg("Could not write last packets after interrupt to Output")
+		}
+	}
+	return true
 }
 
 // Direction returns the direction of the link (upstream or downstream).

--- a/link_test.go
+++ b/link_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/Shopify/toxiproxy/v2/toxics"
 )
 
+// tightRegressionBound catches a regression back to the multi-second bounded
+// wait; the fix path is normally well under 1s.
+const tightRegressionBound = 2 * time.Second
+
 func TestToxicsAreLoaded(t *testing.T) {
 	if toxics.Count() < 1 {
 		t.Fatal("No toxics loaded!")
@@ -322,4 +326,150 @@ func TestRemoveToxicWithBrokenConnection(t *testing.T) {
 
 	collection.chainRemoveToxic(ctx, toxics[0])
 	collection.chainRemoveToxic(ctx, toxics[1])
+}
+
+// TestRemoveToxicDoesNotHangWhenNextToxicStopsReading: a later toxic
+// (reset_peer) closing itself used to leave the earlier one blocked forever
+// forwarding into it, hanging RemoveToxic.
+func TestRemoveToxicDoesNotHangWhenNextToxicStopsReading(t *testing.T) {
+	ctx := context.Background()
+
+	collection := NewToxicCollection(nil)
+	link := NewToxicLink(nil, collection, stream.Downstream, zerolog.Nop())
+	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
+	collection.links["test"] = link
+
+	latency := &toxics.ToxicWrapper{
+		Toxic:      new(toxics.LatencyToxic),
+		Type:       "latency",
+		Direction:  stream.Downstream,
+		BufferSize: 1024,
+		Toxicity:   1,
+	}
+	collection.chainAddToxic(latency)
+
+	// reset_peer reads one chunk, then closes for good.
+	reset := &toxics.ToxicWrapper{
+		Toxic:     &toxics.ResetToxic{Timeout: 0},
+		Type:      "reset_peer",
+		Direction: stream.Downstream,
+		Toxicity:  1,
+	}
+	collection.chainAddToxic(reset)
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		buf := make([]byte, 2)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, _ = link.input.Write(buf)
+			}
+		}
+	}()
+
+	// Give the load a moment to trip reset_peer first.
+	time.Sleep(100 * time.Millisecond)
+
+	err := testhelper.TimeoutAfter(tightRegressionBound, func() {
+		collection.chainRemoveToxic(ctx, latency)
+	})
+	if err != nil {
+		t.Fatalf(
+			"Removing a toxic must not hang when a later toxic in the chain "+
+				"stopped reading on its own: %v",
+			err,
+		)
+	}
+}
+
+// TestWriteClosesWriteDoneWhenDestinationDies: a single latency toxic, no
+// reset_peer, the real destination died instead. write must close
+// link.writeDone once it stops draining link.output.
+func TestWriteClosesWriteDoneWhenDestinationDies(t *testing.T) {
+	server := NewServer(&metricsContainer{}, zerolog.Nop())
+	proxy := NewProxy(server, "test", "localhost:0", "localhost:0")
+	link := NewToxicLink(proxy, proxy.Toxics, stream.Downstream, zerolog.Nop())
+	go link.stubs[0].Run(proxy.Toxics.chain[stream.Downstream][0])
+
+	// A closed PipeReader makes writes to its paired PipeWriter fail immediately.
+	pr, pw := io.Pipe()
+	pr.Close()
+
+	writeReturned := make(chan struct{})
+	go func() {
+		link.write(nil, "test", server, pw)
+		close(writeReturned)
+	}()
+
+	// io.Copy only calls dest.Write once there are bytes to move.
+	go func() {
+		_, _ = link.input.Write([]byte{1, 2, 3})
+		link.input.Close()
+	}()
+
+	select {
+	case <-writeReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("write did not return after its destination failed")
+	}
+
+	select {
+	case <-link.writeDone:
+	default:
+		t.Fatal("writeDone was not closed once write stopped draining link.output")
+	}
+}
+
+// TestRemoveToxicDoesNotHangWhenDestinationDies is the same scenario as
+// TestWriteClosesWriteDoneWhenDestinationDies, through a real removal under load.
+func TestRemoveToxicDoesNotHangWhenDestinationDies(t *testing.T) {
+	ctx := context.Background()
+
+	collection := NewToxicCollection(nil)
+	link := NewToxicLink(nil, collection, stream.Downstream, zerolog.Nop())
+	go link.stubs[0].Run(collection.chain[stream.Downstream][0])
+	collection.links["test"] = link
+
+	latency := &toxics.ToxicWrapper{
+		Toxic:      new(toxics.LatencyToxic),
+		Type:       "latency",
+		Direction:  stream.Downstream,
+		BufferSize: 1024,
+		Toxicity:   1,
+	}
+	collection.chainAddToxic(latency)
+
+	// Simulate what write would do once the real destination died.
+	close(link.writeDone)
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		buf := make([]byte, 2)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, _ = link.input.Write(buf)
+			}
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	err := testhelper.TimeoutAfter(tightRegressionBound, func() {
+		collection.chainRemoveToxic(ctx, latency)
+	})
+	if err != nil {
+		t.Fatalf(
+			"Removing the last toxic must not hang when the real destination "+
+				"already died: %v",
+			err,
+		)
+	}
 }

--- a/toxic_collection.go
+++ b/toxic_collection.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -241,6 +242,7 @@ func (c *ToxicCollection) chainAddToxic(toxic *toxics.ToxicWrapper) {
 		}
 	}
 	wg.Wait()
+	c.refreshOutputTimeouts(dir)
 }
 
 func (c *ToxicCollection) chainUpdateToxic(toxic *toxics.ToxicWrapper) {
@@ -258,6 +260,34 @@ func (c *ToxicCollection) chainUpdateToxic(toxic *toxics.ToxicWrapper) {
 		}
 	}
 	group.Wait()
+	c.refreshOutputTimeouts(toxic.Direction)
+}
+
+// outputTimeout is DefaultOutputTimeout plus the largest ExpectedDelay among
+// dir's toxics. Assumes the lock is already held.
+func (c *ToxicCollection) outputTimeout(dir stream.Direction) time.Duration {
+	timeout := toxics.DefaultOutputTimeout
+	for _, toxic := range c.chain[dir] {
+		delay, ok := toxic.Toxic.(toxics.ExpectedDelay)
+		if !ok {
+			continue
+		}
+		if d := delay.ExpectedDelay() + toxics.DefaultOutputTimeout; d > timeout {
+			timeout = d
+		}
+	}
+	return timeout
+}
+
+// refreshOutputTimeouts recomputes outputTimeout for dir and applies it to
+// every link's stubs in that direction.
+func (c *ToxicCollection) refreshOutputTimeouts(dir stream.Direction) {
+	timeout := c.outputTimeout(dir)
+	for _, link := range c.links {
+		if link.direction == dir {
+			link.setOutputTimeout(timeout)
+		}
+	}
 }
 
 func (c *ToxicCollection) chainRemoveToxic(ctx context.Context, toxic *toxics.ToxicWrapper) {
@@ -274,6 +304,10 @@ func (c *ToxicCollection) chainRemoveToxic(ctx context.Context, toxic *toxics.To
 	for i := toxic.Index; i < len(c.chain[dir]); i++ {
 		c.chain[dir][i].Index = i
 	}
+	// Unlike chainAddToxic/chainUpdateToxic, refresh before the links run:
+	// their flush loops read Timeout as they go, and the toxic being removed
+	// must no longer count toward it.
+	c.refreshOutputTimeouts(dir)
 
 	// Asynchronously remove the toxic from each link
 	wg := sync.WaitGroup{}

--- a/toxics/latency.go
+++ b/toxics/latency.go
@@ -27,6 +27,11 @@ func (t *LatencyToxic) delay() time.Duration {
 	return time.Duration(delay) * time.Millisecond
 }
 
+// ExpectedDelay reports the largest delay this toxic can add to a chunk.
+func (t *LatencyToxic) ExpectedDelay() time.Duration {
+	return time.Duration(t.Latency+t.Jitter) * time.Millisecond
+}
+
 func (t *LatencyToxic) Pipe(stub *ToxicStub) {
 	for {
 		select {
@@ -41,10 +46,11 @@ func (t *LatencyToxic) Pipe(stub *ToxicStub) {
 			select {
 			case <-time.After(sleep):
 				c.Timestamp = c.Timestamp.Add(sleep)
-				stub.Output <- c
+				_ = stub.WriteOutput(c, stub.Timeout())
 			case <-stub.Interrupt:
-				// Exit fast without applying latency.
-				stub.Output <- c // Don't drop any data on the floor
+				// Exit fast without applying latency, but still bounded: the
+				// next toxic may already be gone.
+				_ = stub.WriteOutput(c, stub.Timeout())
 				return
 			}
 		}

--- a/toxics/noop.go
+++ b/toxics/noop.go
@@ -13,7 +13,10 @@ func (t *NoopToxic) Pipe(stub *ToxicStub) {
 				stub.Close()
 				return
 			}
-			stub.Output <- c
+			// Bounded: a plain `stub.Output <- c` blocks forever once the next
+			// toxic stops reading on its own (e.g. reset_peer after one
+			// chunk), which freezes removal too.
+			_ = stub.WriteOutput(c, stub.Timeout())
 		}
 	}
 }

--- a/toxics/toxic.go
+++ b/toxics/toxic.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Shopify/toxiproxy/v2/stream"
@@ -39,6 +40,15 @@ type BufferedToxic interface {
 	GetBufferSize() int
 }
 
+// ExpectedDelay toxics intentionally add latency to a chunk, so a stub's
+// Timeout can account for it instead of mistaking a slow chain for a dead one.
+type ExpectedDelay interface {
+	ExpectedDelay() time.Duration
+}
+
+// DefaultOutputTimeout is the floor added on top of any ExpectedDelay.
+const DefaultOutputTimeout = 5 * time.Second
+
 // Stateful toxics store a per-connection state object on the ToxicStub.
 // The state is created once when the toxic is added and persists until the
 // toxic is removed or the connection is closed.
@@ -65,15 +75,38 @@ type ToxicStub struct {
 	Interrupt chan struct{}
 	running   chan struct{}
 	closed    chan struct{}
+
+	// timeoutNanos bounds a blocked Output send before treating the consumer
+	// as gone. Accessed via Timeout/SetTimeout: ToxicLink writes it under the
+	// collection's lock, Pipe goroutines read it without that lock.
+	timeoutNanos atomic.Int64
+
+	// OutputDone, when set, closes exactly when the stub reading Output stops
+	// for good. WriteOutput selects on it directly instead of checking it
+	// once before sending, so a send already in flight still unblocks the
+	// instant the consumer goes away. Nil for a chain's last stub.
+	OutputDone <-chan struct{}
 }
 
 func NewToxicStub(input <-chan *stream.StreamChunk, output chan<- *stream.StreamChunk) *ToxicStub {
-	return &ToxicStub{
+	s := &ToxicStub{
 		Interrupt: make(chan struct{}),
 		closed:    make(chan struct{}),
 		Input:     input,
 		Output:    output,
 	}
+	s.SetTimeout(DefaultOutputTimeout)
+	return s
+}
+
+// Timeout returns the current send timeout, safe for concurrent use.
+func (s *ToxicStub) Timeout() time.Duration {
+	return time.Duration(s.timeoutNanos.Load())
+}
+
+// SetTimeout updates the send timeout, safe for concurrent use.
+func (s *ToxicStub) SetTimeout(d time.Duration) {
+	s.timeoutNanos.Store(int64(d))
 }
 
 // Begin running a toxic on this stub, can be interrupted.
@@ -93,13 +126,19 @@ func (s *ToxicStub) Run(toxic *ToxicWrapper) {
 // If duration is 0, then wait until other goroutines finish reading from Output.
 func (s *ToxicStub) WriteOutput(p *stream.StreamChunk, d time.Duration) error {
 	if d == 0 {
-		s.Output <- p
-		return nil
+		select {
+		case s.Output <- p:
+			return nil
+		case <-s.OutputDone:
+			return fmt.Errorf("output already closed")
+		}
 	}
 
 	select {
 	case s.Output <- p:
 		return nil
+	case <-s.OutputDone:
+		return fmt.Errorf("output already closed")
 	case <-time.After(d):
 		return fmt.Errorf("timeout: could not write to output in %d seconds", int(d.Seconds()))
 	}
@@ -124,6 +163,11 @@ func (s *ToxicStub) Closed() bool {
 	default:
 		return false
 	}
+}
+
+// Done reports when this stub itself stops; see ToxicStub.OutputDone.
+func (s *ToxicStub) Done() <-chan struct{} {
+	return s.closed
 }
 
 func (s *ToxicStub) Close() {


### PR DESCRIPTION
Toxics (noop, latency) forwarded chunks with a plain, unbounded `stub.Output <- chunk`. If nothing was left reading that channel, the send blocked forever and could never be interrupted, so RemoveToxic hung while holding the collection's mutex, freezing the whole control API (reads included).

- ToxicStub.OutputDone and ToxicLink.writeDone let a send react instantly when the next toxic already closed itself, or the real destination connection already died.
- Otherwise, the send is bounded by a timeout derived from the chain's own configured delay, so a legitimately slow chain isn't mistaken for a dead one.
- Draining a removed toxic's leftover queue no longer retries a known-dead sink item by item.

Fixes #558, #427, #428.