### PR TITLE
ensure config file is closed in PopulateConfig

### DIFF
--- a/api.go
+++ b/api.go
@@ -150,6 +150,7 @@ func (server *ApiServer) PopulateConfig(filename string) {
 		logger.Err(err).Str("config", filename).Msg("Error reading config file")
 		return
 	}
+	defer file.Close()
 
 	proxies, err := server.Collection.PopulateJson(server, file)
 	if err != nil {


### PR DESCRIPTION
### Summary
This PR resolves an unclosed file descriptor resource leak in `ApiServer.PopulateConfig` by ensuring that configuration files opened via `os.Open` are properly closed after decoding.

### Root Cause Analysis
In `api.go`, the `PopulateConfig` method opens a JSON configuration file to populate proxies during server startup or reload.

While `PopulateJson` consumes the passed `io.Reader` via `json.NewDecoder(data).Decode(...)`, it does not take ownership of closing the underlying stream. As a result, the `*os.File` handle allocated by `os.Open(filename)` remains open indefinitely for the lifetime of the process.

### Solution
Add `defer file.Close()` immediately following the successful `os.Open` error check. This guarantees that the file descriptor is released back to the OS regardless of whether JSON decoding succeeds or fails.

### Changes Made
- Modified `api.go` in `PopulateConfig`: added `defer file.Close()` right after the initial error check.