### PR TITLE
fix(toxics/slicer): never overflow the stack or slice out of range

### DIFF
--- a/toxics/slicer.go
+++ b/toxics/slicer.go
@@ -33,7 +33,9 @@ func (t *SlicerToxic) chunk(start int, end int) []int {
 	// If the size is within the random varation, _or already
 	// less than the average size_, just return it.
 	// Otherwise split the chunk in about two, and recurse.
-	if (end-start)-t.AverageSize <= t.SizeVariation {
+	// An average size of zero or less slices nothing, and a piece of
+	// fewer than two bytes cannot be split.
+	if t.AverageSize <= 0 || end-start < 2 || (end-start)-t.AverageSize <= t.SizeVariation {
 		return []int{start, end}
 	}
 
@@ -41,6 +43,12 @@ func (t *SlicerToxic) chunk(start int, end int) []int {
 
 	if t.SizeVariation > 0 {
 		mid += rand.Intn(t.SizeVariation*2) - t.SizeVariation // #nosec G404 -- was ignored before too
+	}
+	// Keep the split inside the piece so both halves are shorter than it.
+	if mid <= start {
+		mid = start + 1
+	} else if mid >= end {
+		mid = end - 1
 	}
 	left := t.chunk(start, mid)
 	right := t.chunk(mid, end)

--- a/toxics/slicer_termination_test.go
+++ b/toxics/slicer_termination_test.go
@@ -1,0 +1,56 @@
+package toxics_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/Shopify/toxiproxy/v2/stream"
+	"github.com/Shopify/toxiproxy/v2/toxics"
+)
+
+// Every attribute combination must slice a packet into pieces that reassemble
+// exactly, including the zero defaults `toxiproxy-cli toxic add -t slicer`
+// sends and a size_variation larger than average_size.
+func TestSlicerReassemblesForAnyAttributes(t *testing.T) {
+	params := []struct{ average, variation int }{
+		{0, 0}, {0, 5}, {-1, 0}, {1, 0}, {2, 1}, {5, 10}, {10, 10}, {64, 8}, {1024, 512},
+	}
+	sizes := []int{1, 2, 21, 64, 1000, 4096}
+
+	for _, p := range params {
+		for _, size := range sizes {
+			toxic := &toxics.SlicerToxic{AverageSize: p.average, SizeVariation: p.variation}
+			payload := make([]byte, size)
+			for i := range payload {
+				payload[i] = byte(i % 251)
+			}
+
+			input := make(chan *stream.StreamChunk, 1)
+			output := make(chan *stream.StreamChunk, size+16)
+			stub := toxics.NewToxicStub(input, output)
+
+			done := make(chan []byte, 1)
+			go func() {
+				var got bytes.Buffer
+				for chunk := range output {
+					got.Write(chunk.Data)
+				}
+				done <- got.Bytes()
+			}()
+
+			go toxic.Pipe(stub)
+			input <- &stream.StreamChunk{Data: payload, Timestamp: time.Now()}
+			close(input)
+
+			select {
+			case got := <-done:
+				if !bytes.Equal(got, payload) {
+					t.Errorf("params %+v size %d: reassembled %d bytes, want %d", p, size, len(got), size)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatalf("params %+v size %d: no output within 5s", p, size)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #541.

`SlicerToxic.chunk` recurses on an interval that never shrinks when `average_size` is 0, which is what `toxiproxy-cli toxic add -t slicer <proxy>` sends when no attributes are given: the first byte through the proxy ends the server with `fatal error: stack overflow`. With `size_variation` at or above `average_size` the jittered midpoint can land outside the piece, and `Pipe` panics with `slice bounds out of range` (#541).

`chunk` now returns the piece whole when `average_size` is 0 or less or the piece is under two bytes, and clamps the midpoint inside the piece so both halves are shorter than it. Slicing for attributes that already worked is unchanged.

The new test drives nine attribute pairs, including the zero defaults and `size_variation > average_size`, over six payload sizes and checks the pieces reassemble byte for byte. On main it dies with the stack overflow.

`make test`, `go vet ./...` pass.
